### PR TITLE
Refactor to improve lines of code script

### DIFF
--- a/e2e-network/test-01-simple.sh
+++ b/e2e-network/test-01-simple.sh
@@ -20,7 +20,7 @@ dumpLogs() {
 
 networkDown() {
   rm -rf "$TEST_LOGS"
-  (for name in $(docker ps --format '{{.Names}}'); do dumpLogs "$name"; done)
+  (docker ps --format '{{.Names}}' | while read -r name; do dumpLogs "$name"; done)
   (cd "$TEST_TMP" && "$FABLO_HOME/fablo.sh" down)
 }
 

--- a/e2e/create-test-cases.sh
+++ b/e2e/create-test-cases.sh
@@ -4,15 +4,16 @@ set -e
 
 FABLO_HOME="$(dirname "$0")/.."
 
-(
-  cd "$FABLO_HOME/samples"
-  for f in fablo-config-*; do
-    echo "import performTests from \"./performTests\";
+cd "$FABLO_HOME/samples"
 
-const config = \"samples/$f\";
+for f in fablo-config-*; do
+    cat > "../e2e/${f}.test.ts" <<EOF
+import performTests from "./performTests";
+
+const config = "samples/$f";
 
 describe(config, () => {
   performTests(config);
-});" >"../e2e/${f}.test.ts"
-  done
-)
+});
+EOF
+done

--- a/e2e/performTests.ts
+++ b/e2e/performTests.ts
@@ -1,13 +1,13 @@
 import TestCommands from "./TestCommands";
 import { resolve } from "path";
 
-const testFilesExistence = (config: string, files: string[]) => {
+const testFilesExistence = (config: string, files: string[]): void => {
   it(`should create proper files from ${config}`, () => {
     expect(files).toMatchSnapshot();
   });
 };
 
-const testFilesContent = (commands: TestCommands, config: string, files: string[]) =>
+const testFilesContent = (commands: TestCommands, config: string, files: string[]): void => {
   files.forEach((f) => {
     it(`should create proper ${f} from ${config}`, () => {
       const content = commands.getFileContent(`${commands.relativeRoot}/${f}`);
@@ -21,6 +21,7 @@ const testFilesContent = (commands: TestCommands, config: string, files: string[
       expect(cleaned).toMatchSnapshot();
     });
   });
+};
 
 export default (config: string): void => {
   const commands = new TestCommands(`e2e/__tmp__/${config}.tmpdir`);


### PR DESCRIPTION
Used cat instead of echo to write multi-line text, and used a here-document (<<EOF) to make the code more readable.
Used read -r to avoid issues with backslashes in container names.
Added TypeScript type annotations for the function parameters and return types.

cc @dzikowski 