### PR TITLE
Dropped support for capabilities v1

### DIFF
--- a/src/extend-config/extendGlobal.ts
+++ b/src/extend-config/extendGlobal.ts
@@ -5,13 +5,11 @@ import { GlobalJson } from "../types/FabloConfigJson";
 import defaults from "./defaults";
 
 const getNetworkCapabilities = (fabricVersion: string): Capabilities => {
-  if (version(fabricVersion).isGreaterOrEqual("2.0.0"))
-    return { channel: "V2_0", orderer: "V2_0", application: "V2_0", isV2: true };
-
+  
   if (version(fabricVersion).isGreaterOrEqual("2.5.0"))
     return { channel: "V2_5", orderer: "V2_5", application: "V2_5", isV2: true };
 
-  return { channel: "V1_3", orderer: "V1_1", application: "V1_3", isV2: false };
+  return { channel: "V2_0", orderer: "V2_0", application: "V2_0", isV2: true };
 };
 
 const getVersions = (fabricVersion: string): FabricVersions => {

--- a/src/types/FabloConfigExtended.ts
+++ b/src/types/FabloConfigExtended.ts
@@ -8,13 +8,6 @@ export interface FabricVersions {
   fabricRecommendedNodeVersion: string;
 }
 
-interface CapabilitiesV1 {
-  application: "V1_3" | "V1_4_2";
-  channel: "V1_3" | "V1_4_2" | "V1_4_3";
-  orderer: "V1_1" | "V1_4_2";
-  isV2: false;
-}
-
 interface CapabilitiesV2 {
   application: "V2_0";
   channel: "V2_0";
@@ -32,7 +25,7 @@ interface CapabilitiesV_2_5 {
 
 
 
-export type Capabilities = CapabilitiesV1 | CapabilitiesV2 | CapabilitiesV_2_5;
+export type Capabilities = CapabilitiesV2 | CapabilitiesV_2_5;
 
 export interface Global extends FabricVersions {
   tls: boolean;


### PR DESCRIPTION
fixes #453 
I have dropped the respective interface and have made the required changes by carefully looking jumping from dependencies, imports and exports of the interfaces, but this is still work in progress cause I want to which interface or error shall I return if the version is less than 2.0