### PR TITLE
Fix #519: Check if post-generate.sh exists before executing

### DIFF
--- a/fablo.sh
+++ b/fablo.sh
@@ -191,7 +191,11 @@ generateNetworkConfig() {
 
   mkdir -p "$fablo_target"
   executeOnFabloDocker "fablo:setup-network" "$fablo_target" "$fablo_config"
-  ("$fablo_target/hooks/post-generate.sh")
+  if [ -f "$fablo_target/hooks/post-generate.sh" ]; then
+    ("$fablo_target/hooks/post-generate.sh")
+  else
+    echo "Note: No post-generate.sh hook found. This might be due to validation errors in your configuration."
+  fi
 }
 
 networkPrune() {

--- a/fablo.sh
+++ b/fablo.sh
@@ -193,8 +193,6 @@ generateNetworkConfig() {
   executeOnFabloDocker "fablo:setup-network" "$fablo_target" "$fablo_config"
   if [ -f "$fablo_target/hooks/post-generate.sh" ]; then
     ("$fablo_target/hooks/post-generate.sh")
-  else
-    echo "Note: No post-generate.sh hook found. This might be due to validation errors in your configuration."
   fi
 }
 


### PR DESCRIPTION
This PR fixes issue #519 where Fablo shows a misleading error when starting an invalid network.

Issue:- The problem was that when there's an error in the config file (like RAFT with no TLS), the post-generate.sh file is not created, but the script tries to execute it anyway, resulting in a misleading error message.

Changes made:
- Added a check to verify if post-generate.sh exists before executing it
- The script now silently skips the post-generate hook if it doesn't exist

Fixes #519
I would be happy to make any further changes in the code.
![Screenshot from 2025-04-12 12-05-10](https://github.com/user-attachments/assets/c7972afe-e1bf-426f-b8d4-290d833e8d2e)
