### PR TITLE
Fix #340: Connection profile - bugs and missing values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 * Full support for Fabric 3.0.0 and drop solo consensus
   [#513](https://github.com/hyperledger-labs/fablo/pull/513)
 
+### Bug Fixes
+* Fix connection profile issues (CA URL, missing orderers and channels sections)
+  [#340](https://github.com/hyperledger-labs/fablo/issues/340)
+
 ## 2.1.0
 
 ### Features
@@ -129,7 +133,7 @@
 ## 0.3.0
 
 ### Features
-* Add [Fablo REST](https://github.com/fablo-io/fablo-rest/) support 
+* Add [Fablo REST](https://github.com/fablo-io/fablo-rest/) support
 * By default all peers are anchor peers
 * Support `postGenerate` hook
 * Added support for [Orderer sharding](https://github.com/hyperledger-labs/fablo/issues/220) (multiple orderer groups).

--- a/src/setup-docker/index.ts
+++ b/src/setup-docker/index.ts
@@ -54,7 +54,7 @@ export default class SetupDockerGenerator extends Generator {
 
     // ======= fabric-config ============================================================
     this._copyOrgCryptoConfig(orgs);
-    this._createConnectionProfiles(global, orgs);
+    this._createConnectionProfiles(global, orgs, channels, config.ordererGroups);
     this._createFabricCaServerConfigs(orgs);
     this._createExplorerMaterial(global, orgs, channels);
     this._copyConfigTx(config);
@@ -101,9 +101,9 @@ export default class SetupDockerGenerator extends Generator {
     });
   }
 
-  _createConnectionProfiles(global: Global, orgsTransformed: OrgConfig[]): void {
+  _createConnectionProfiles(global: Global, orgsTransformed: OrgConfig[], channels: ChannelConfig[] = [], ordererGroups: OrdererGroup[] = []): void {
     orgsTransformed.forEach((org: OrgConfig) => {
-      const connectionProfile = createConnectionProfile(global, org, orgsTransformed);
+      const connectionProfile = createConnectionProfile(global, org, orgsTransformed, channels, ordererGroups);
       this.fs.writeJSON(
         this.destinationPath(`fabric-config/connection-profiles/connection-profile-${org.name.toLowerCase()}.json`),
         connectionProfile,

--- a/src/setup-docker/index.ts
+++ b/src/setup-docker/index.ts
@@ -101,7 +101,7 @@ export default class SetupDockerGenerator extends Generator {
     });
   }
 
-  _createConnectionProfiles(global: Global, orgsTransformed: OrgConfig[], channels: ChannelConfig[] = [], ordererGroups: OrdererGroup[] = []): void {
+  _createConnectionProfiles(global: Global, orgsTransformed: OrgConfig[], channels: ChannelConfig[], ordererGroups: OrdererGroup[]): void {
     orgsTransformed.forEach((org: OrgConfig) => {
       const connectionProfile = createConnectionProfile(global, org, orgsTransformed, channels, ordererGroups);
       this.fs.writeJSON(

--- a/src/types/ConnectionProfile.ts
+++ b/src/types/ConnectionProfile.ts
@@ -10,6 +10,8 @@ interface BaseConnectionProfile {
 interface ConnectionProfile extends BaseConnectionProfile {
   client: Client;
   organizations: { [key: string]: Organization };
+  orderers?: { [key: string]: Orderer };
+  channels?: { [name: string]: Channel };
   certificateAuthorities: { [key: string]: CertificateAuthority };
 }
 
@@ -24,6 +26,12 @@ interface Organization {
 }
 
 interface Peer {
+  url: string;
+  tlsCACerts?: TlsCACerts;
+  grpcOptions?: { [key: string]: string };
+}
+
+interface Orderer {
   url: string;
   tlsCACerts?: TlsCACerts;
   grpcOptions?: { [key: string]: string };
@@ -152,29 +160,54 @@ function certificateAuthorities(
   rootPath: string,
   org: OrgConfig,
 ): { [key: string]: CertificateAuthority } {
-  if (isTls) {
-    return {
-      [org.ca.address]: {
-        url: `https://localhost:${org.ca.exposePort}`,
-        caName: org.ca.address,
-        tlsCACerts: {
-          path: `${rootPath}/peerOrganizations/${org.domain}/ca/${org.ca.address}-cert.pem`,
-        },
-        httpOptions: {
-          verify: false,
-        },
-      },
-    };
-  }
-  return {
-    [org.ca.address]: {
-      url: `http://localhost:${org.ca.exposePort}`,
-      caName: org.ca.address,
-      httpOptions: {
-        verify: false,
-      },
+  const protocol = isTls ? 'https' : 'http';
+  const caConfig: CertificateAuthority = {
+    url: `${protocol}://localhost:${org.ca.exposePort}`,
+    caName: org.ca.address,
+    httpOptions: {
+      verify: false,
     },
   };
+
+  if (isTls) {
+    caConfig.tlsCACerts = {
+      path: `${rootPath}/peerOrganizations/${org.domain}/ca/${org.ca.address}-cert.pem`,
+    };
+  }
+
+  return {
+    [org.ca.address]: caConfig,
+  };
+}
+
+function createOrderers(
+  isTls: boolean,
+  rootPath: string,
+  ordererGroups: OrdererGroup[],
+): { [key: string]: Orderer } {
+  const orderers: { [key: string]: Orderer } = {};
+
+  ordererGroups.forEach((group) => {
+    group.orderers.forEach((orderer) => {
+      if (isTls) {
+        orderers[orderer.address] = {
+          url: `grpcs://localhost:${orderer.port}`,
+          tlsCACerts: {
+            path: `${rootPath}/ordererOrganizations/${orderer.domain}/orderers/${orderer.address}/tls/ca.crt`,
+          },
+          grpcOptions: {
+            "ssl-target-name-override": orderer.address,
+          },
+        };
+      } else {
+        orderers[orderer.address] = {
+          url: `grpc://localhost:${orderer.port}`,
+        };
+      }
+    });
+  });
+
+  return orderers;
 }
 
 function createChannels(org: OrgConfig, channels: ChannelConfig[]): { [name: string]: Channel } {
@@ -187,10 +220,13 @@ function createChannels(org: OrgConfig, channels: ChannelConfig[]): { [name: str
   return cs;
 }
 
-export function createConnectionProfile(global: Global, org: OrgConfig, orgs: OrgConfig[]): ConnectionProfile {
+export function createConnectionProfile(global: Global, org: OrgConfig, orgs: OrgConfig[], channels: ChannelConfig[] = [], ordererGroups: OrdererGroup[] = []): ConnectionProfile {
   const rootPath = `${global.paths.chaincodesBaseDir}/fablo-target/fabric-config/crypto-config`;
   const peers = createPeers(org.name, false, global.tls, rootPath, orgs);
-  return {
+  const orderers = createOrderers(global.tls, rootPath, ordererGroups);
+  const channelsObj = createChannels(org, channels);
+
+  const profile: ConnectionProfile = {
     name: `fablo-test-network-${org.name.toLowerCase()}`,
     description: `Connection profile for ${org.name} in Fablo network`,
     version: "1.0.0",
@@ -207,6 +243,18 @@ export function createConnectionProfile(global: Global, org: OrgConfig, orgs: Or
     peers: peers,
     certificateAuthorities: certificateAuthorities(global.tls, rootPath, org),
   };
+
+  // Add orderers section if there are any orderers
+  if (Object.keys(orderers).length > 0) {
+    profile.orderers = orderers;
+  }
+
+  // Add channels section if there are any channels
+  if (Object.keys(channelsObj).length > 0) {
+    profile.channels = channelsObj;
+  }
+
+  return profile;
 }
 
 export function createExplorerConnectionProfile(


### PR DESCRIPTION
This PR fixes issue #340 by addressing the following issues with connection profiles:

1. CA URL in connection profile starts from `http://`, even if TLS is enabled
   - Fixed by ensuring the protocol is set based on TLS settings

2. Missing `orderers` section (required when service discovery is disabled)
   - Added orderers section to connection profiles

3. Missing `channels` section (required when service discovery is disabled)
   - Added channels section to connection profiles

These changes ensure that Node.js clients can use the connection profiles with service discovery disabled, which is particularly important in dev mode.

Fixes #340