### PR TITLE
Fix #111: Add post-start hook functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Features
 * Full support for Fabric 3.0.0 and drop solo consensus
   [#513](https://github.com/hyperledger-labs/fablo/pull/513)
+* Add post-start hook functionality
+  [#111](https://github.com/hyperledger-labs/fablo/issues/111)
 
 ## 2.1.0
 
@@ -129,7 +131,7 @@
 ## 0.3.0
 
 ### Features
-* Add [Fablo REST](https://github.com/fablo-io/fablo-rest/) support 
+* Add [Fablo REST](https://github.com/fablo-io/fablo-rest/) support
 * By default all peers are anchor peers
 * Support `postGenerate` hook
 * Added support for [Orderer sharding](https://github.com/hyperledger-labs/fablo/issues/220) (multiple orderer groups).

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To create a local Hyperledger Fabric network with Node.js chaincode and REST API
 ```bash
 fablo init node rest    # if installed globally
 # or
-./fablo init node rest  # if using local script 
+./fablo init node rest  # if using local script
 ./fablo up
 ```
 
@@ -76,7 +76,7 @@ fablo init [node] [rest] [dev]
 ```
 
 Creates simple network config file in current dir.
-Good step to start your adventure with Fablo or set up a fast prototype. 
+Good step to start your adventure with Fablo or set up a fast prototype.
 
 Fablo `init` command takes three parameters (the order does not matter):
 * Option `node` makes Fablo to generate a sample Node.js chaincode as well.
@@ -140,7 +140,7 @@ fablo recreate [/path/to/fablo-config.json|yaml]
 ```
 
 * `reset` -- down and up steps combined. Network state is lost, but the configuration is kept intact. Useful in cases when you want a fresh instance of network without any state.
-* `recreate` -- prunes the network, generates new config files and ups the network. Useful when you edited `fablo-config` file and want to start newer network version in one command.    
+* `recreate` -- prunes the network, generates new config files and ups the network. Useful when you edited `fablo-config` file and want to start newer network version in one command.
 
 ### validate
 
@@ -149,7 +149,7 @@ fablo validate [/path/to/fablo-config.json|yaml]
 ```
 
 Validates network config. This command will validate your network config try to suggest necessary changes or additional tweaks.
-Please note that this step is also executed automatically before each `generate` to ensure that at least critical errors where fixed. 
+Please note that this step is also executed automatically before each `generate` to ensure that at least critical errors where fixed.
 
 ### snapshot and restore
 
@@ -215,7 +215,7 @@ Chaincode directory is specified in Fablo config file.
 Invokes chaincode with specified parameters.
 
 ```
-fablo chaincode invoke <peers-domains-comma-separated>  <channel-name>  <chaincode-name> <command> [transient] 
+fablo chaincode invoke <peers-domains-comma-separated>  <channel-name>  <chaincode-name> <command> [transient]
 ```
 Sample command:
 
@@ -224,7 +224,7 @@ fablo chaincode invoke "peer0.org1.example.com" "my-channel1" "chaincode1" '{"Ar
 ```
 
 ### chaincodes list
-Gets the instantiated or installed chaincodes in the specified channel or peer. 
+Gets the instantiated or installed chaincodes in the specified channel or peer.
 
 ```
 fablo chaincodes list <peer> <channel>
@@ -277,11 +277,11 @@ Feel free to update this scripts to adjust it to your chaincode definition.
 ```bash
 fablo channel --help
 ```
-Use it to list all available channel commands.  
+Use it to list all available channel commands.
 Commands are generated using fablo-config.json to cover all cases (queries for each channel. organization and peer)
 
 ### channel list
- 
+
 ```bash
 fablo channel list org1 peer0
 ```
@@ -323,7 +323,7 @@ With optional `-v` or `--verbose` flag it prints supported Fablo and Hyperledger
 
 ```bash
 fablo use
-```   
+```
 
 Lists all available Fablo versions.
 
@@ -331,7 +331,7 @@ Lists all available Fablo versions.
 
 ```bash
 fablo use <version-number>
-```   
+```
 
 Switches current script to selected version.
 
@@ -411,14 +411,14 @@ The other available parameters for entries in `orgs` array are:
  * `orderers` (defaults to empty: `[]`)
  * `tools.explorer` - whether run Blockchain Explorer for the organization (default: `false`)
  * `tools.fabloRest` - whether run Fablo REST for the organization (default: `false`)
- 
-### property `peer.db`:  
-- may be `LevelDb` (default) or `CouchDb`.  
 
-### property `orderers`:  
+### property `peer.db`:
+- may be `LevelDb` (default) or `CouchDb`.
+
+### property `orderers`:
 - is optional as some organizations may have orderer defined, but some don't.
-- At least one orderer group is required to run Fabric network (requirement is validated before run).   
-- If you want to spread orderers in group between many organizations use same `groupName` in every group definition.  
+- At least one orderer group is required to run Fabric network (requirement is validated before run).
+- If you want to spread orderers in group between many organizations use same `groupName` in every group definition.
 - The property `orderers.type` may be `solo` or `raft`. We do not support the Kafka orderer.
 
 ### channels
@@ -429,7 +429,7 @@ Example:
   "channels": [
     {
       "name": "my-channel1",
-      "groupName": "group1",      
+      "groupName": "group1",
       "orgs": [
         {
           "name": "Org1",
@@ -450,7 +450,7 @@ Example:
   ],
 ```
 
-- Property `groupName` is optional (defaults to first orderer group found). If you want to handle channel with different orderer group define it in `orgs` and pass it's name here. 
+- Property `groupName` is optional (defaults to first orderer group found). If you want to handle channel with different orderer group define it in `orgs` and pass it's name here.
 
 ### chaincodes
 
@@ -491,18 +491,21 @@ The `privateData` parameter is optional. You don't need to define the private da
 ### hooks
 
 Hooks in Fablo are Bash commands to be executed after a specific event.
-Right now Fablo supports only one kind of hook: `postGenerate`.
-It will be executed each time after the network config is generated -- after `./fablo generate` command (executed separately or automatically by `./fablo up`).
+Fablo supports the following hooks:
+
+1. `postGenerate` - executed each time after the network config is generated -- after `./fablo generate` command (executed separately or automatically by `./fablo up`).
+2. `postStart` - executed after the network is started -- after `./fablo up` or `./fablo start` command.
 
 The following hook example will change `MaxMessageCount` to 1 in generated Hyperledger Fabric config:
 
 ```json
   "hooks": {
-    "postGenerate": "perl -i -pe 's/MaxMessageCount: 10/MaxMessageCount: 1/g' \"./fablo-target/fabric-config/configtx.yaml\""
+    "postGenerate": "perl -i -pe 's/MaxMessageCount: 10/MaxMessageCount: 1/g' \"./fablo-target/fabric-config/configtx.yaml\"",
+    "postStart": "echo 'Network started successfully!' && curl -X POST https://example.com/webhook/network-started"
   }
 ```
 
-Genrated Hooks are saved in `fablo-target/hooks`.
+Generated Hooks are saved in `fablo-target/hooks`.
 
 
 ### Sample YAML config file
@@ -521,7 +524,7 @@ orgs:
       - groupName: group1
         prefix: orderer
         type: solo
-        instances: 1 
+        instances: 1
   - organization:
       name: Org1
       domain: org1.example.com

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -535,6 +535,12 @@
           "title": "Post generate hook",
           "description": "Operation to run run after a network config is generated",
           "type": "string"
+        },
+        "postStart": {
+          "$id": "#/properties/hooks/postStart",
+          "title": "Post start hook",
+          "description": "Operation to run after a network is started",
+          "type": "string"
         }
       }
     }

--- a/src/extend-config/extendHooksConfig.ts
+++ b/src/extend-config/extendHooksConfig.ts
@@ -3,8 +3,10 @@ import { HooksConfig } from "../types/FabloConfigExtended";
 
 const extendHooksConfig = (hooksJson: HooksJson | undefined): HooksConfig => {
   const postGenerate = typeof hooksJson?.postGenerate === "string" ? hooksJson.postGenerate : "";
+  const postStart = typeof hooksJson?.postStart === "string" ? hooksJson.postStart : "";
   return {
     postGenerate,
+    postStart,
   };
 };
 export default extendHooksConfig;

--- a/src/setup-docker/index.ts
+++ b/src/setup-docker/index.ts
@@ -245,5 +245,8 @@ export default class SetupDockerGenerator extends Generator {
     this.fs.copyTpl(this.templatePath("hooks/post-generate.sh"), this.destinationPath("hooks/post-generate.sh"), {
       hooks,
     });
+    this.fs.copyTpl(this.templatePath("hooks/post-start.sh"), this.destinationPath("hooks/post-start.sh"), {
+      hooks,
+    });
   }
 }

--- a/src/setup-docker/templates/fabric-docker.sh
+++ b/src/setup-docker/templates/fabric-docker.sh
@@ -21,6 +21,9 @@ networkUp() {
   installChannels
   installChaincodes
   notifyOrgsAboutChannels
+  if [ -f "$FABLO_NETWORK_ROOT/hooks/post-start.sh" ]; then
+    ("$FABLO_NETWORK_ROOT/hooks/post-start.sh")
+  fi
   printStartSuccessInfo
 }
 
@@ -46,7 +49,7 @@ elif [ "$1" = "chaincode" ] && [ "$2" = "dev" ]; then
 elif [ "$1" = "chaincode" ] && [ "$2" = "invoke" ]; then
   chaincodeInvoke "$3" "$4" "$5" "$6" "$7"
 elif [ "$1" = "chaincodes" ] && [ "$2" = "list" ]; then
-  chaincodeList "$3" "$4"  
+  chaincodeList "$3" "$4"
 elif [ "$1" = "channel" ]; then
   channelQuery "${@:2}"
 elif [ "$1" = "snapshot" ]; then

--- a/src/setup-docker/templates/hooks/post-start.sh
+++ b/src/setup-docker/templates/hooks/post-start.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# The code from this file is called after Fablo starts the Hyperledger Fabric network
+echo "Executing post-start hook"
+
+<%- hooks.postStart %>

--- a/src/setup-k8s/index.ts
+++ b/src/setup-k8s/index.ts
@@ -111,5 +111,8 @@ export default class SetupDockerGenerator extends Generator {
     this.fs.copyTpl(this.templatePath("hooks/post-generate.sh"), this.destinationPath("hooks/post-generate.sh"), {
       hooks,
     });
+    this.fs.copyTpl(this.templatePath("hooks/post-start.sh"), this.destinationPath("hooks/post-start.sh"), {
+      hooks,
+    });
   }
 }

--- a/src/setup-k8s/templates/fabric-k8s.sh
+++ b/src/setup-k8s/templates/fabric-k8s.sh
@@ -23,6 +23,9 @@ networkUp() {
   deployOrderer
   installChannels
   installChaincodes
+  if [ -f "$FABLO_NETWORK_ROOT/hooks/post-start.sh" ]; then
+    ("$FABLO_NETWORK_ROOT/hooks/post-start.sh")
+  fi
   printHeadline "Done! Enjoy your fresh network" "U1F984"
 }
 

--- a/src/setup-k8s/templates/hooks/post-start.sh
+++ b/src/setup-k8s/templates/hooks/post-start.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# The code from this file is called after Fablo starts the Hyperledger Fabric network
+echo "Executing post-start hook"
+
+<%- hooks.postStart %>

--- a/src/types/FabloConfigExtended.ts
+++ b/src/types/FabloConfigExtended.ts
@@ -172,6 +172,7 @@ export interface OrdererGroup {
 
 export interface HooksConfig {
   postGenerate: string;
+  postStart: string;
 }
 
 export interface FabloConfigExtended {

--- a/src/types/FabloConfigJson.ts
+++ b/src/types/FabloConfigJson.ts
@@ -65,6 +65,7 @@ export interface ChaincodeJson {
 
 export interface HooksJson {
   postGenerate?: string;
+  postStart?: string;
 }
 
 export interface FabloConfigJson {


### PR DESCRIPTION
This PR fixes issue #111 by adding post-start hook functionality.

Changes made:
- Added a new `postStart` hook type that is executed after the network is started
- Updated the configuration interfaces and extension logic to handle the new hook
- Created template files for the post-start hook
- Updated the network startup scripts to execute the post-start hook
- Updated documentation to explain the new hook functionality

This allows users to define custom actions to be performed after the network is started, which can be useful for various post-startup tasks like sending notifications, running additional setup scripts, or deploying applications that depend on the network.

Fixes #111