### PR TITLE
Fix #519: Check if post-generate.sh exists before executing

### DIFF
--- a/fablo.sh
+++ b/fablo.sh
@@ -191,7 +191,9 @@ generateNetworkConfig() {
 
   mkdir -p "$fablo_target"
   executeOnFabloDocker "fablo:setup-network" "$fablo_target" "$fablo_config"
-  ("$fablo_target/hooks/post-generate.sh")
+  if [ -f "$fablo_target/hooks/post-generate.sh" ]; then
+    ("$fablo_target/hooks/post-generate.sh")
+  fi
 }
 
 networkPrune() {


### PR DESCRIPTION
This PR fixes [Issue #519](https://github.com/hyperledger-labs/fablo/issues/519).

After changes (current behaviour) :
![image](https://github.com/user-attachments/assets/f4983299-919e-4d08-8d8a-440d79eb7150)
