### PR TITLE
docs: split command reference into focused guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,194 +87,42 @@ Fablo will manage it locally.
 On the other hand you can use Fablo to generate initial network configuration, keep it in version control and tweak for specific requirements.
 In this case, however, you should use generated `fablo-docker.sh` instead of `fablo` script.
 
-## Managing the network
+## Command guides
 
-### init
+Fablo command documentation has been split into focused pages for easier onboarding and maintenance.
 
-```bash
-fablo init [node] [rest] [dev] [gateway]
-```
+### Start here
 
-Creates a simple network configuration file (`fablo-config.json`) in the current directory.
-This is a good starting point for your Fablo journey or to set up a quick prototype. 
+- [docs/commands/README.md](docs/commands/README.md)
 
-The generated network configuration includes an orderer organization with two BFT orderer nodes and a peer organization with two peers.
-It uses Fabric version `3.1.0`. 
+### Network setup and lifecycle
 
-The `fablo init` command accepts several optional parameters (order doesn't matter):
-* `node` - generates a sample Node.js chaincode
-* `rest` - enables a simple REST API with [Fablo REST](https://github.com/fablo-io/fablo-rest) as a standalone Docker container
-* `dev` - enables chaincode hot reload mode
-* `gateway` - generates a sample Node.js server that connects to the gateway
+- [init](docs/commands/init.md)
+- [generate](docs/commands/generate.md)
+- [up](docs/commands/up.md)
+- [down, start, stop](docs/commands/down-start-stop.md)
+- [prune, reset, recreate](docs/commands/prune-reset-recreate.md)
+- [snapshot and restore](docs/commands/snapshot-restore.md)
 
-Sample command:
+### Config and diagnostics
 
-```bash
-fablo init node dev
-```
+- [validate](docs/commands/validate.md)
+- [extend-config](docs/commands/extend-config.md)
+- [export-network-topology](docs/commands/export-network-topology.md)
 
-### generate
+### Chaincode and channel operations
 
-```bash
-fablo generate [/path/to/fablo-config.json|yaml [/path/to/fablo/target]]
-```
+- [chaincode commands](docs/commands/chaincode.md)
+- [channel commands](docs/commands/channel.md)
 
-Generates network configuration files in the specified directory.
-Default config file path is `$(pwd)/fablo-config.json` or `$(pwd)/fablo-config.yaml`, default directory is `$(pwd)/fablo-target`.
-If you specify a different directory, you lose Fablo support for other commands.
+### Utility commands
 
-If you want to use Fablo only to generate the Hyperledger Fabric network configuration, you can provide a target directory parameter or copy the generated `fablo-target` directory content to your desired directory and add it to version control.
-Note that generated files may contain variables with paths on your disk and generated crypto material for Hyperledger Fabric.
-Review the files before committing to version control.
-
-### up
-
-```bash
-fablo up [/path/to/fablo-config.json|yaml]
-```
-
-Starts the Hyperledger Fabric network for the given Fablo configuration file, creates channels, and installs and instantiates chaincodes.
-If no configuration exists, it will call the `generate` command for the given config file.
-
-### down, start, stop
-
-```bash
-fablo [down | start | stop]
-```
-
-Stops, starts, or stops the Hyperledger Fabric network for the configuration in the current directory.
-This is similar to the down, start, and stop commands for Docker Compose.
-
-### prune
-
-```bash
-fablo prune
-```
-
-Stops the network and removes the `fablo-target` directory.
-
-### reset and recreate
-
-```bash
-fablo reset
-fablo recreate [/path/to/fablo-config.json|yaml]
-```
-
-* `reset` - combines down and up steps. Network state is lost, but the configuration is kept intact. Useful when you want a fresh network instance without any state.
-* `recreate` - prunes the network, generates new config files, and starts the network. Useful when you've edited the `fablo-config` file and want to start a newer network version in one command.    
-
-### validate
-
-```bash
-fablo validate [/path/to/fablo-config.json|yaml]
-```
-
-Validates the network configuration. This command will validate your network config and suggest necessary changes or additional tweaks.
-Note that this step is also executed automatically before each `generate` to ensure that at least critical errors are fixed. 
-
-### export-network-topology
-
-```bash
-fablo export-network-topology [/path/to/fablo-config.json] [outputFile.mmd]
-
-```
-- `outputFile.mmd`: (optional) Path to the output Mermaid file. Defaults to `network-topology.mmd`.
-
-Sample command:
-
-```bash
-fablo export-network-topology fablo-config.json network-topology.mmd
-```
-
-You can visualize the output using any Mermaid-compatible tool or online editor.
-
-### extend-config 
-
-```bash
-fablo extend-config [/path/to/fablo-config.json|yaml]
-```
-
-Generates an extended version of the Fablo config by filling in default and computed values based on the provided configuration file and making some config parts more verbos. 
-
-### snapshot and restore
-
-Fablo supports saving state snapshots (backups) of the network and restoring them.
-It saves all network artifacts, certificates, and data from CA, orderer, and peer nodes.
-Note that the snapshot does not contain the Fablo config file and chaincode source code, as both can be located outside the Fablo working directory.
-
-Snapshotting is useful if you want to preserve the current state of a network for future use (testing, sharing the network state, courses, etc.).
-
-```bash
-fablo snapshot <target-snapshot-path>
-```
-
-To restore a snapshot into the current directory, run:
-
-```bash
-fablo restore <source-snapshot-path>
-```
-
-Example:
-
-1. Assume you have a working network with some state.
-2. Run `./fablo snapshot /tmp/my-snapshot`. This creates a file `/tmp/my-snapshot.fablo.tar.gz` with the network state. You don't need to stop the network before making a snapshot.
-3. Run `./fablo prune` to destroy the current network. If the network is present, Fablo won't be able to restore the new one from backup.
-4. Run `./fablo restore /tmp/my-snapshot` to restore the network.
-5. Run `./fablo start` to start the restored network.
-6. When running external chaincodes (CCAAS), run `./fablo chaincodes install` to start the CCAAS container
-
-Typically, a snapshot of a network with little data will be less than 1 MB, making it easy to share.
+- [version and use](docs/commands/version-use.md)
 
 ### fabric-docker.sh
 
-The `fabric-docker.sh` script is generated alongside the Docker network configuration.
-It doesn't support the `generate` command, but other commands work the same way as in `fablo`.
-Essentially, `fablo` forwards some commands to this script.
-
-If you want to use Fablo for network configuration setup only, the `fabric-docker.sh` file allows you to manage the network.
-
-## Managing chaincodes
-
-### chaincode(s) install
-
-```bash
-fablo chaincodes install
-```
-Installs all chaincodes. This might be useful if Fablo fails to install them automatically.
-
-To install a single chaincode defined in the Fablo config file, run:
-
-```bash
-fablo chaincode install <chaincode-name> <version>
-```
-
-### chaincode upgrade
-
-```bash
-fablo chaincode upgrade <chaincode-name> <version>
-```
-
-Upgrades the chaincode with the given name on all relevant peers.
-The chaincode directory is specified in the Fablo config file.
-
-### chaincode invoke
-Invokes a chaincode with the specified parameters.
-
-```
-fablo chaincode invoke <peers-domains-comma-separated>  <channel-name>  <chaincode-name> <command> [transient] 
-```
-Sample command:
-
-```
-fablo chaincode invoke "peer0.org1.example.com" "my-channel1" "chaincode1" '{"Args":["KVContract:put", "name", "Willy Wonka"]}'
-```
-
-### chaincodes list
-Lists the instantiated or installed chaincodes in the specified channel or peer. 
-
-```
-fablo chaincodes list <peer> <channel>
-```
+The `fabric-docker.sh` script is generated alongside Docker network configuration.
+It does not support `generate`, but other lifecycle commands mirror `fablo` behavior.
 
 ### Achieving chaincode hot reload
 
@@ -383,70 +231,7 @@ This produces the following chaincode configuration:
 You can find a full end-to-end example in one of our test scripts [test-01-v3-simple.sh](e2e-network/docker/test-01-v3-simple.sh).
 
 
-## Channel scripts
-
-### channel help
-
-```bash
-fablo channel --help
-```
-Use it to list all available channel commands.
-Commands are generated using fablo-config.json to cover all cases (queries for each channel, organization, and peer).
-
-### channel list
- 
-```bash
-fablo channel list org1 peer0
-```
-Lists all channels for the given peer.
-
-### channel getinfo
-
-```bash
-fablo channel getinfo channel_name org1 peer0
-```
-Prints channel info, such as current block height for the given peer
-
-### channel fetch config
-
-```bash
-fablo channel fetch config channel_name org1 peer0 [file_name.json]
-```
-
-Fetches the latest config block, decodes it, and writes it to a JSON file.
-
-### channel fetch raw block
-
-```bash
-fablo channel fetch <oldest|newest|block-number> channel_name org1 peer0 [file_name.json]
-```
-Fetches the oldest, newest, or a block with the given number, and writes it to a file.
-
-## Utility commands
-
-### version
-
-```bash
-fablo version [--verbose | -v]
-```
-Prints the current Fablo version.
-With the optional `-v` or `--verbose` flag, it also prints supported Fablo and Hyperledger Fabric versions.
-
-### use
-
-```bash
-fablo use
-```   
-
-Lists all available Fablo versions.
-
-### use <version-number>
-
-```bash
-fablo use <version-number>
-```   
-
-Switches the current script to the selected version.
+For detailed channel and utility command references, use the command guides in [docs/commands/README.md](docs/commands/README.md).
 
 ## Fablo config
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -1,0 +1,33 @@
+# Fablo Command Guides
+
+This section contains practical command guides with purpose, arguments, examples, and expected output.
+
+## Network setup and lifecycle
+
+- [init](init.md)
+- [generate](generate.md)
+- [up](up.md)
+- [down-start-stop](down-start-stop.md)
+- [prune-reset-recreate](prune-reset-recreate.md)
+- [snapshot-restore](snapshot-restore.md)
+
+## Config and diagnostics
+
+- [validate](validate.md)
+- [extend-config](extend-config.md)
+- [export-network-topology](export-network-topology.md)
+
+## Chaincode and channel operations
+
+- [chaincode](chaincode.md)
+- [channel](channel.md)
+
+## Utility
+
+- [version-use](version-use.md)
+
+## Notes
+
+- Use ./fablo if the script is local to your project.
+- Use fablo if installed globally.
+- Most lifecycle commands operate on fablo-target generated in the current directory.

--- a/docs/commands/chaincode.md
+++ b/docs/commands/chaincode.md
@@ -1,0 +1,49 @@
+# chaincode commands
+
+Commands for installing, upgrading, invoking, and querying chaincodes.
+
+## Install all chaincodes
+
+```bash
+fablo chaincodes install
+```
+
+## Install one chaincode
+
+```bash
+fablo chaincode install <chaincode-name> <version>
+```
+
+## Upgrade chaincode
+
+```bash
+fablo chaincode upgrade <chaincode-name> <version>
+```
+
+## Invoke
+
+```bash
+fablo chaincode invoke <peers-domains-comma-separated> <channel-name> <chaincode-name> <command> [transient]
+```
+
+## Query
+
+```bash
+fablo chaincode query <peer-domain> <channel-name> <chaincode-name> <command> [transient]
+```
+
+## List
+
+```bash
+fablo chaincodes list <peer> <channel>
+```
+
+## Example invoke
+
+```bash
+fablo chaincode invoke "peer0.org1.example.com" "my-channel1" "chaincode1" '{"Args":["KVContract:put", "name", "Willy Wonka"]}'
+```
+
+## Hot reload guidance
+
+For development mode and CCaaS hot reload patterns, see the section in [README.md](../../README.md#achieving-chaincode-hot-reload).

--- a/docs/commands/chaincode.md
+++ b/docs/commands/chaincode.md
@@ -2,6 +2,12 @@
 
 Commands for installing, upgrading, invoking, and querying chaincodes.
 
+For contributors running from source on Windows, this equivalent command avoids CRLF issues in `fablo.sh`:
+
+```powershell
+bash -lc "sed 's/\r$//' ./fablo.sh | bash -s -- chaincodes list peer0.org1.example.com my-channel1"
+```
+
 ## Install all chaincodes
 
 ```bash
@@ -38,6 +44,20 @@ fablo chaincode query <peer-domain> <channel-name> <chaincode-name> <command> [t
 fablo chaincodes list <peer> <channel>
 ```
 
+## Sample terminal output (chaincodes list)
+
+```text
+$ fablo chaincodes list peer0.org1.example.com my-channel1
+Executing Fablo Docker command: chaincodes
+Chaincodes list:
+	PEER_ADDRESS: peer0.org1.example.com:7041
+	CHANNEL_NAME: my-channel1
+	CA_CERT: crypto-orderer/tlsca.orderer.example.com-cert.pem
+...
+Committed chaincode definitions on channel 'my-channel1':
+Name: chaincode1, Version: 0.0.1, Sequence: 1
+```
+
 ## Example invoke
 
 ```bash
@@ -47,3 +67,9 @@ fablo chaincode invoke "peer0.org1.example.com" "my-channel1" "chaincode1" '{"Ar
 ## Hot reload guidance
 
 For development mode and CCaaS hot reload patterns, see the section in [README.md](../../README.md#achieving-chaincode-hot-reload).
+
+## When to use
+
+- `chaincodes install` when chaincode startup failed during `fablo up`.
+- `chaincode upgrade` after changing chaincode code or metadata version.
+- `chaincode invoke/query` during integration testing and local debugging.

--- a/docs/commands/channel.md
+++ b/docs/commands/channel.md
@@ -2,6 +2,12 @@
 
 Read channel state and fetch blocks/config from a peer context.
 
+For contributors running from source on Windows, this equivalent command avoids CRLF issues in `fablo.sh`:
+
+```powershell
+bash -lc "sed 's/\r$//' ./fablo.sh | bash -s -- channel list org1 peer0"
+```
+
 ## Help
 
 ```bash
@@ -32,6 +38,23 @@ fablo channel fetch config channel_name org1 peer0 [file_name.json]
 fablo channel fetch <oldest|newest|block-number> channel_name org1 peer0 [file_name.json]
 ```
 
+## Sample terminal output (channel list)
+
+```text
+$ fablo channel list org1 peer0
+Executing Fablo Docker command: channel
+Listing channels using cli.org1.example.com using peer peer0.org1.example.com:7041 (TLS)...
+...
+Channels peers has joined:
+my-channel1
+```
+
 ## Expected output
 
 - Lists, JSON files, or block files depending on selected subcommand.
+
+## When to use
+
+- Verifying that peers joined expected channels after `fablo up`.
+- Fetching channel config for update workflows.
+- Troubleshooting channel state during integration tests.

--- a/docs/commands/channel.md
+++ b/docs/commands/channel.md
@@ -1,0 +1,37 @@
+# channel commands
+
+Read channel state and fetch blocks/config from a peer context.
+
+## Help
+
+```bash
+fablo channel --help
+```
+
+## List channels
+
+```bash
+fablo channel list org1 peer0
+```
+
+## Channel info
+
+```bash
+fablo channel getinfo channel_name org1 peer0
+```
+
+## Fetch decoded config
+
+```bash
+fablo channel fetch config channel_name org1 peer0 [file_name.json]
+```
+
+## Fetch raw block
+
+```bash
+fablo channel fetch <oldest|newest|block-number> channel_name org1 peer0 [file_name.json]
+```
+
+## Expected output
+
+- Lists, JSON files, or block files depending on selected subcommand.

--- a/docs/commands/down-start-stop.md
+++ b/docs/commands/down-start-stop.md
@@ -1,0 +1,28 @@
+# down, start, stop
+
+Controls lifecycle of an already generated network.
+
+## Syntax
+
+```bash
+fablo down
+fablo start
+fablo stop
+```
+
+## Behavior
+
+- down: Stops and removes running network containers.
+- stop: Stops containers without deleting generated artifacts.
+- start: Restarts previously stopped containers.
+
+## Example
+
+```bash
+fablo stop
+fablo start
+```
+
+## Expected output
+
+- Container lifecycle actions similar to Docker Compose workflows.

--- a/docs/commands/export-network-topology.md
+++ b/docs/commands/export-network-topology.md
@@ -1,0 +1,24 @@
+# export-network-topology
+
+Exports network topology as Mermaid diagram source.
+
+## Syntax
+
+```bash
+fablo export-network-topology [/path/to/fablo-config.json] [outputFile.mmd]
+```
+
+## Parameters
+
+- Config path (optional): Input config.
+- outputFile.mmd (optional): Output Mermaid file path. Default is network-topology.mmd.
+
+## Example
+
+```bash
+fablo export-network-topology fablo-config.json network-topology.mmd
+```
+
+## Expected output
+
+- Mermaid file that can be rendered by Mermaid-compatible tools.

--- a/docs/commands/extend-config.md
+++ b/docs/commands/extend-config.md
@@ -1,0 +1,24 @@
+# extend-config
+
+Prints an expanded version of your config with defaults and computed values.
+
+## Syntax
+
+```bash
+fablo extend-config [/path/to/fablo-config.json|yaml]
+```
+
+## Example
+
+```bash
+fablo extend-config fablo-config.json
+```
+
+## Expected output
+
+- JSON output to terminal that includes derived fields and defaults.
+
+## When to use
+
+- Debugging configuration behavior.
+- Verifying effective values before generation.

--- a/docs/commands/generate.md
+++ b/docs/commands/generate.md
@@ -19,12 +19,54 @@ fablo generate [/path/to/fablo-config.json|yaml [/path/to/fablo-target]]
 fablo generate fablo-config.yaml
 ```
 
+For contributors running from source on Windows, this equivalent command avoids CRLF issues in `fablo.sh`:
+
+```powershell
+bash -lc "sed 's/\r$//' ./fablo.sh | bash -s -- generate fablo-config.json"
+```
+
+## What gets generated
+
+The command creates `fablo-target` with Docker orchestration scripts, Fabric config files, helper hooks, and topology output.
+
+Typical generated files include:
+
+- `fablo-target/fablo-config.json`
+- `fablo-target/fabric-docker.sh`
+- `fablo-target/network-topology.mmd`
+- `fablo-target/fabric-config/configtx.yaml`
+- `fablo-target/fabric-config/crypto-config-orderer.yaml`
+- `fablo-target/fabric-config/crypto-config-org1.yaml`
+- `fablo-target/fabric-config/connection-profiles/connection-profile-org1.json`
+
+## Sample terminal output
+
+```text
+$ fablo generate fablo-config.json
+Generating network config
+	FABLO_VERSION:      2.5.0
+	FABLO_CONFIG:       fablo-config.json
+	FABLO_NETWORK_ROOT: /.../fablo-target
+Setting up network based on config: fablo-config.json
+Used network config: /network/workspace/fablo-config.json
+Fabric version is: 3.1.0
+Generating docker-compose network 'fablo_network_202604061753'...
+✅ Network topology exported to /network/workspace/network-topology.mmd
+Done & done !!! Try the network out:
+-> fablo up - to start network
+-> fablo help - to view all commands
+Formatting generated files
+Executing post-generate hook
+```
+
 ## Expected output
 
-- Generated scripts and Fabric configuration files in fablo-target.
-- No running containers are started by this command.
+- A fully generated `fablo-target` directory.
+- No peer/orderer/CA containers are started.
+- You can inspect and modify generated files before running `fablo up`.
 
 ## When to use
 
 - Reviewing generated files before startup.
-- Versioning generated artifacts for custom workflows.
+- Debugging configuration behavior (what config values resolve to in output files).
+- Versioning generated artifacts for custom workflows and CI baselines.

--- a/docs/commands/generate.md
+++ b/docs/commands/generate.md
@@ -1,0 +1,30 @@
+# generate
+
+Generates network artifacts from your Fablo config without starting the network.
+
+## Syntax
+
+```bash
+fablo generate [/path/to/fablo-config.json|yaml [/path/to/fablo-target]]
+```
+
+## Parameters
+
+- Config path (optional): Input JSON or YAML config.
+- Target path (optional): Output directory for generated artifacts.
+
+## Example
+
+```bash
+fablo generate fablo-config.yaml
+```
+
+## Expected output
+
+- Generated scripts and Fabric configuration files in fablo-target.
+- No running containers are started by this command.
+
+## When to use
+
+- Reviewing generated files before startup.
+- Versioning generated artifacts for custom workflows.

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -21,12 +21,69 @@ fablo init [node] [rest] [dev] [gateway]
 fablo init node rest
 ```
 
+## What gets generated
+
+- `fablo-config.json`
+- `chaincodes/chaincode-kv-node/.nvmrc`
+- `chaincodes/chaincode-kv-node/Dockerfile`
+- `chaincodes/chaincode-kv-node/index.js`
+- `chaincodes/chaincode-kv-node/package.json`
+- `chaincodes/chaincode-kv-node/package-lock.json`
+
+## Sample terminal output
+
+```text
+$ fablo init node rest
+Sample config file created! :)
+You can start your network with 'fablo up' command
+========================================
+```
+
 ## Expected output
 
-- A new fablo-config.json file.
-- Optional sample chaincode and/or gateway files, based on selected flags.
+- A generated `fablo-config.json` with a ready-to-run two-org sample topology.
+- Optional sample assets depending on selected flags (for this example: Node chaincode and REST-enabled org settings).
+
+## Sample generated config snippet
+
+```json
+{
+	"$schema": "https://github.com/hyperledger-labs/fablo/releases/download/2.5.0/schema.json",
+	"global": {
+		"fabricVersion": "3.1.0",
+		"tls": true,
+		"peerDevMode": false,
+		"engine": "docker"
+	},
+	"orgs": [
+		{
+			"organization": {
+				"name": "Orderer",
+				"domain": "orderer.example.com",
+				"mspName": "OrdererMSP"
+			},
+			"ca": {
+				"prefix": "ca",
+				"db": "sqlite"
+			},
+			"orderers": [
+				{
+					"groupName": "group1",
+					"type": "BFT",
+					"instances": 2,
+					"prefix": "orderer"
+				}
+			],
+			"tools": {
+				"fabloRest": true
+			}
+		}
+	]
+}
+```
 
 ## When to use
 
 - Starting a new local Fabric playground quickly.
 - Bootstrapping an example config before customization.
+- Creating a reproducible starter layout for workshops, demos, or onboarding.

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -1,0 +1,32 @@
+# init
+
+Creates a starter Fablo configuration in the current directory.
+
+## Syntax
+
+```bash
+fablo init [node] [rest] [dev] [gateway]
+```
+
+## Parameters
+
+- node: Adds sample Node.js chaincode.
+- rest: Enables Fablo REST container.
+- dev: Enables development workflow for chaincode hot reload.
+- gateway: Adds sample Node.js gateway app.
+
+## Example
+
+```bash
+fablo init node rest
+```
+
+## Expected output
+
+- A new fablo-config.json file.
+- Optional sample chaincode and/or gateway files, based on selected flags.
+
+## When to use
+
+- Starting a new local Fabric playground quickly.
+- Bootstrapping an example config before customization.

--- a/docs/commands/prune-reset-recreate.md
+++ b/docs/commands/prune-reset-recreate.md
@@ -1,0 +1,29 @@
+# prune, reset, recreate
+
+Commands for clean rebuild workflows.
+
+## Syntax
+
+```bash
+fablo prune
+fablo reset
+fablo recreate [/path/to/fablo-config.json|yaml]
+```
+
+## Behavior
+
+- prune: Stops network and removes fablo-target.
+- reset: Recreates runtime state by running down + up while preserving generated setup.
+- recreate: Removes target, regenerates files from config, then starts network.
+
+## Example
+
+```bash
+fablo recreate fablo-config.json
+```
+
+## When to use
+
+- prune: Full cleanup.
+- reset: Fresh ledger state with same topology.
+- recreate: Apply updated config changes end-to-end.

--- a/docs/commands/snapshot-restore.md
+++ b/docs/commands/snapshot-restore.md
@@ -1,0 +1,29 @@
+# snapshot and restore
+
+Backs up and restores network state artifacts.
+
+## Syntax
+
+```bash
+fablo snapshot <target-snapshot-path>
+fablo restore <source-snapshot-path>
+```
+
+## Behavior
+
+- snapshot: Creates a .fablo.tar.gz archive with network state and certificates.
+- restore: Restores snapshot into current working directory.
+
+## Example flow
+
+```bash
+fablo snapshot /tmp/my-snapshot
+fablo prune
+fablo restore /tmp/my-snapshot
+fablo start
+```
+
+## Notes
+
+- Snapshot does not include your source config and chaincode source directories.
+- For external chaincodes, run chaincodes install after restore.

--- a/docs/commands/up.md
+++ b/docs/commands/up.md
@@ -18,11 +18,47 @@ fablo up [/path/to/fablo-config.json|yaml]
 fablo up
 ```
 
+For contributors running from source on Windows, this equivalent command avoids CRLF issues in `fablo.sh`:
+
+```powershell
+bash -lc "sed 's/\r$//' ./fablo.sh | bash -s -- up fablo-config.json"
+```
+
+## What this command does
+
+`up` runs the full startup workflow:
+
+- Generates missing artifacts in `fablo-target` (if not present).
+- Generates crypto/config artifacts.
+- Starts orderers, peers, CAs, and optional tools.
+- Creates channels, installs/approves/commits chaincode definitions.
+
+## Sample terminal output
+
+```text
+$ fablo up fablo-config.json
+Executing Fablo Docker command: up
+Generating basic configs
+Generating crypto material for Orderer
+Generating certs...
+	CONFIG_PATH: /mnt/c/fablo/tmp-docs-snippets/fablo-target/fabric-config
+Unable to find image 'ghcr.io/fablo-io/fabric-tools:3.1.3' locally
+3.1.3: Pulling from fablo-io/fabric-tools
+...
+ClientWait -> txid [...] committed with status (VALID) at peer0.org1.example.com:7041
+
+Done! Enjoy your fresh network
+Executing post-start hook
+```
+
 ## Expected output
 
-- Network containers are created and started.
-- Channels are created and chaincodes are installed/instantiated according to config.
+- Running Fabric containers in Docker (`orderer`, `peer`, `ca`, and optional tools).
+- Channels created and chaincodes installed/approved/committed based on config.
+- A ready network that can be queried with `fablo chaincode query` or channel commands.
 
 ## When to use
 
 - Running the full network from your current project config.
+- Recreating a realistic local environment before app or chaincode development.
+- Validating your config changes end-to-end before opening a pull request.

--- a/docs/commands/up.md
+++ b/docs/commands/up.md
@@ -1,0 +1,28 @@
+# up
+
+Generates (if needed) and starts the Fabric network.
+
+## Syntax
+
+```bash
+fablo up [/path/to/fablo-config.json|yaml]
+```
+
+## Parameters
+
+- Config path (optional): Input config file.
+
+## Example
+
+```bash
+fablo up
+```
+
+## Expected output
+
+- Network containers are created and started.
+- Channels are created and chaincodes are installed/instantiated according to config.
+
+## When to use
+
+- Running the full network from your current project config.

--- a/docs/commands/validate.md
+++ b/docs/commands/validate.md
@@ -1,0 +1,29 @@
+# validate
+
+Validates a Fablo configuration file.
+
+## Syntax
+
+```bash
+fablo validate [/path/to/fablo-config.json|yaml]
+```
+
+## What it checks
+
+- JSON schema compatibility.
+- Critical config consistency and required fields.
+
+## Example
+
+```bash
+fablo validate fablo-config.yaml
+```
+
+## Expected output
+
+- Success: confirmation that config is valid.
+- Failure: actionable validation errors printed in terminal.
+
+## Tip
+
+Run validate before generate or up to fail fast on config issues.

--- a/docs/commands/validate.md
+++ b/docs/commands/validate.md
@@ -19,6 +19,28 @@ fablo validate [/path/to/fablo-config.json|yaml]
 fablo validate fablo-config.yaml
 ```
 
+For contributors running from source on Windows, this equivalent command avoids CRLF issues in `fablo.sh`:
+
+```powershell
+bash -lc "sed 's/\r$//' ./fablo.sh | bash -s -- validate fablo-config.json"
+```
+
+## Sample terminal output
+
+```text
+$ fablo validate fablo-config.json
+Validation errors count: 0
+Validation warnings count: 0
+===========================================================
+```
+
+## Common validation failure example
+
+```text
+Validation errors count: 1
+- chaincodes[0].directory is required for lang=node
+```
+
 ## Expected output
 
 - Success: confirmation that config is valid.
@@ -27,3 +49,8 @@ fablo validate fablo-config.yaml
 ## Tip
 
 Run validate before generate or up to fail fast on config issues.
+
+## When to use
+
+- Before opening a PR with config/template changes.
+- In CI pipelines to catch invalid topology changes early.

--- a/docs/commands/version-use.md
+++ b/docs/commands/version-use.md
@@ -1,0 +1,32 @@
+# version and use
+
+Utility commands for inspecting and switching Fablo versions.
+
+## Show current version
+
+```bash
+fablo version
+```
+
+## Verbose version details
+
+```bash
+fablo version --verbose
+```
+
+## List available versions
+
+```bash
+fablo use
+```
+
+## Switch to specific version
+
+```bash
+fablo use <version-number>
+```
+
+## Notes
+
+- Version switching applies to the script installation context.
+- Verify with fablo version after switching.


### PR DESCRIPTION
This PR moves command references from a long README section into focused guides under README.md, and updates README.md to link to them.

Fixes #667 
