### PR TITLE
fix: emit ERROR instead of WARN when Explorer is enabled with Fabric v3

### DIFF
--- a/src/commands/validate/index.ts
+++ b/src/commands/validate/index.ts
@@ -517,6 +517,30 @@ export default class Validate extends Command {
 
   _validateExplorerWithFabricVersion(global: GlobalJson, orgs: OrgJson[]): void {
     const fabricVersion = global.fabricVersion;
+    const explorerEnabled =
+      global.tools?.explorer === true || orgs.some((o) => o.tools?.explorer === true);
+
+    if (!explorerEnabled) return;
+
+    // Fabric v3+ is definitively unsupported by Hyperledger Explorer
+    if (version(fabricVersion).isGreaterOrEqual("3.0.0")) {
+      const errorMessage = `Hyperledger Explorer does not support Fabric v3. Disable Explorer or use Fabric 2.5.x.`;
+      if (global.tools?.explorer === true) {
+        this.emit(validationErrorType.ERROR, { category: validationCategories.GENERAL, message: errorMessage });
+      } else {
+        orgs
+          .filter((o) => o.tools?.explorer === true)
+          .forEach(() => {
+            this.emit(validationErrorType.ERROR, {
+              category: validationCategories.ORGS,
+              message: errorMessage,
+            });
+          });
+      }
+      return;
+    }
+
+    // Fabric below 1.4 or above 2.5.12 — soft advisory
     if (!version(fabricVersion).isGreaterOrEqual("1.4.0") || version(fabricVersion).isGreaterOrEqual("2.5.13")) {
       const warnMessage = `You are using fabric version '${global.fabricVersion}' which may not be supported by the Hyperledger Explorer`;
       if (global.tools?.explorer === true) {


### PR DESCRIPTION
Closes #<688
## What this does
Fixes the `_validateExplorerWithFabricVersion` method in `src/commands/validate/index.ts` to emit a validation **error** (not a warning) when Hyperledger Explorer is enabled with Fabric v3+.
Explorer does not support Fabric v3 — this is a known incompatibility. Previously, the validator only warned about it, allowing `fablo generate` and `fablo up` to produce a broken network where the Explorer container fails silently at runtime.
## Changes
**File:** `src/commands/validate/index.ts`
- Added an early return when Explorer is not enabled (avoids unnecessary version checks)
- Added a new `version >= 3.0.0` check that emits `validationErrorType.ERROR` with a clear message: *"Hyperledger Explorer does not support Fabric v3. Disable Explorer or use Fabric 2.5.x."*
- Preserved the existing `WARN` behavior for other edge cases (Fabric below 1.4, Fabric above 2.5.12 but below 3.0)
- Handles both global-level and org-level Explorer enablement, consistent with existing code
## Behavior matrix
| Fabric version | Explorer enabled | Before | After |
|---|---|---|---|
| `3.1.0` | ✅ | ⚠️ WARN (network generates, Explorer breaks) | ❌ ERROR (blocks generation) |
| `2.5.9` | ✅ | ✅ No message | ✅ No message |
| `2.5.14` | ✅ | ⚠️ WARN | ⚠️ WARN |
| Any | ❌ | No check | Early return |
## Scope
1 file changed, 24 insertions, 0 deletions. No other files modified.