### PR TITLE
fix(ccaas): use peer-specific archive name to prevent package overwrite

### DIFF
--- a/e2e/__snapshots__/fablo-config-hlf2-1org-1chaincode-peer-dev-mode.json.test.ts.snap
+++ b/e2e/__snapshots__/fablo-config-hlf2-1org-1chaincode-peer-dev-mode.json.test.ts.snap
@@ -2590,6 +2590,7 @@ chaincodePackageCCaaS() {
   local CHANNEL_NAME=$9
   local ORG_DOMAIN=\${10}
   local CHAINCODE_LABEL="\${CHANNEL_NAME}_\${CHAINCODE_NAME}_$CHAINCODE_VERSION"
+  local PEER_NAME="\${PEER_ADDRESS%:*}"
 
   echo "Packaging CCaaS chaincode $CHAINCODE_NAME..."
   inputLog "CHAINCODE_VERSION: $CHAINCODE_VERSION"
@@ -2637,14 +2638,14 @@ chaincodePackageCCaaS() {
   fi
 
   tar -czf "$PACKAGE_DIR/code.tar.gz" -C "$PACKAGE_DIR/code" connection.json
-  tar -czf "./chaincode-packages/$CHAINCODE_LABEL.tar.gz" -C "$PACKAGE_DIR" metadata.json code.tar.gz
+  tar -czf "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" -C "$PACKAGE_DIR" metadata.json code.tar.gz
 
-  docker cp "./chaincode-packages/$CHAINCODE_LABEL.tar.gz" "$CLI_NAME:/var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  docker cp "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" "$CLI_NAME:/var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
 
-  rm "./chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  rm "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
   rm -rf "$PACKAGE_DIR"
 
-  echo "CCaaS package created at /var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  echo "CCaaS package created at /var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
 }
 
 chaincodeInstall() {
@@ -2655,12 +2656,20 @@ chaincodeInstall() {
   local CHANNEL_NAME=$5
   local CA_CERT=\${6:-}
   local CHAINCODE_LABEL="\${CHANNEL_NAME}_\${CHAINCODE_NAME}_$CHAINCODE_VERSION"
+  local PEER_NAME="\${PEER_ADDRESS%:*}"
+
+  # Use peer-specific package if available (CCaaS), otherwise fall back to shared package
+  local PACKAGE_FILE="$CHAINCODE_LABEL.tar.gz"
+  if docker exec "$CLI_NAME" test -f "/var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" 2>/dev/null; then
+    PACKAGE_FILE="\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
+  fi
 
   echo "Installing chaincode $CHAINCODE_NAME..."
   inputLog "CHAINCODE_VERSION: $CHAINCODE_VERSION"
   inputLog "PEER_ADDRESS: $PEER_ADDRESS"
   inputLog "CHANNEL_NAME: $CHANNEL_NAME"
   inputLog "CHAINCODE_LABEL: $CHAINCODE_LABEL"
+  inputLog "PACKAGE_FILE: $PACKAGE_FILE"
   inputLog "CA_CERT: $CA_CERT"
 
   local CA_CERT_PARAMS=()
@@ -2669,7 +2678,7 @@ chaincodeInstall() {
   fi
 
   docker exec -e CORE_PEER_ADDRESS="$PEER_ADDRESS" "$CLI_NAME" peer lifecycle chaincode install \\
-    "/var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz" \\
+    "/var/hyperledger/cli/chaincode-packages/$PACKAGE_FILE" \\
     "\${CA_CERT_PARAMS[@]+"\${CA_CERT_PARAMS[@]}"}"
 }
 

--- a/e2e/__snapshots__/fablo-config-hlf2-1org-1chaincode.json.test.ts.snap
+++ b/e2e/__snapshots__/fablo-config-hlf2-1org-1chaincode.json.test.ts.snap
@@ -2644,6 +2644,7 @@ chaincodePackageCCaaS() {
   local CHANNEL_NAME=$9
   local ORG_DOMAIN=\${10}
   local CHAINCODE_LABEL="\${CHANNEL_NAME}_\${CHAINCODE_NAME}_$CHAINCODE_VERSION"
+  local PEER_NAME="\${PEER_ADDRESS%:*}"
 
   echo "Packaging CCaaS chaincode $CHAINCODE_NAME..."
   inputLog "CHAINCODE_VERSION: $CHAINCODE_VERSION"
@@ -2691,14 +2692,14 @@ chaincodePackageCCaaS() {
   fi
 
   tar -czf "$PACKAGE_DIR/code.tar.gz" -C "$PACKAGE_DIR/code" connection.json
-  tar -czf "./chaincode-packages/$CHAINCODE_LABEL.tar.gz" -C "$PACKAGE_DIR" metadata.json code.tar.gz
+  tar -czf "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" -C "$PACKAGE_DIR" metadata.json code.tar.gz
 
-  docker cp "./chaincode-packages/$CHAINCODE_LABEL.tar.gz" "$CLI_NAME:/var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  docker cp "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" "$CLI_NAME:/var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
 
-  rm "./chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  rm "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
   rm -rf "$PACKAGE_DIR"
 
-  echo "CCaaS package created at /var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  echo "CCaaS package created at /var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
 }
 
 chaincodeInstall() {
@@ -2709,12 +2710,20 @@ chaincodeInstall() {
   local CHANNEL_NAME=$5
   local CA_CERT=\${6:-}
   local CHAINCODE_LABEL="\${CHANNEL_NAME}_\${CHAINCODE_NAME}_$CHAINCODE_VERSION"
+  local PEER_NAME="\${PEER_ADDRESS%:*}"
+
+  # Use peer-specific package if available (CCaaS), otherwise fall back to shared package
+  local PACKAGE_FILE="$CHAINCODE_LABEL.tar.gz"
+  if docker exec "$CLI_NAME" test -f "/var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" 2>/dev/null; then
+    PACKAGE_FILE="\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
+  fi
 
   echo "Installing chaincode $CHAINCODE_NAME..."
   inputLog "CHAINCODE_VERSION: $CHAINCODE_VERSION"
   inputLog "PEER_ADDRESS: $PEER_ADDRESS"
   inputLog "CHANNEL_NAME: $CHANNEL_NAME"
   inputLog "CHAINCODE_LABEL: $CHAINCODE_LABEL"
+  inputLog "PACKAGE_FILE: $PACKAGE_FILE"
   inputLog "CA_CERT: $CA_CERT"
 
   local CA_CERT_PARAMS=()
@@ -2723,7 +2732,7 @@ chaincodeInstall() {
   fi
 
   docker exec -e CORE_PEER_ADDRESS="$PEER_ADDRESS" "$CLI_NAME" peer lifecycle chaincode install \\
-    "/var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz" \\
+    "/var/hyperledger/cli/chaincode-packages/$PACKAGE_FILE" \\
     "\${CA_CERT_PARAMS[@]+"\${CA_CERT_PARAMS[@]}"}"
 }
 

--- a/e2e/__snapshots__/fablo-config-hlf2-1org-2chaincode-raft-ccaas.json.test.ts.snap
+++ b/e2e/__snapshots__/fablo-config-hlf2-1org-2chaincode-raft-ccaas.json.test.ts.snap
@@ -2830,6 +2830,7 @@ chaincodePackageCCaaS() {
   local CHANNEL_NAME=$9
   local ORG_DOMAIN=\${10}
   local CHAINCODE_LABEL="\${CHANNEL_NAME}_\${CHAINCODE_NAME}_$CHAINCODE_VERSION"
+  local PEER_NAME="\${PEER_ADDRESS%:*}"
 
   echo "Packaging CCaaS chaincode $CHAINCODE_NAME..."
   inputLog "CHAINCODE_VERSION: $CHAINCODE_VERSION"
@@ -2877,14 +2878,14 @@ chaincodePackageCCaaS() {
   fi
 
   tar -czf "$PACKAGE_DIR/code.tar.gz" -C "$PACKAGE_DIR/code" connection.json
-  tar -czf "./chaincode-packages/$CHAINCODE_LABEL.tar.gz" -C "$PACKAGE_DIR" metadata.json code.tar.gz
+  tar -czf "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" -C "$PACKAGE_DIR" metadata.json code.tar.gz
 
-  docker cp "./chaincode-packages/$CHAINCODE_LABEL.tar.gz" "$CLI_NAME:/var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  docker cp "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" "$CLI_NAME:/var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
 
-  rm "./chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  rm "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
   rm -rf "$PACKAGE_DIR"
 
-  echo "CCaaS package created at /var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  echo "CCaaS package created at /var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
 }
 
 chaincodeInstall() {
@@ -2895,12 +2896,20 @@ chaincodeInstall() {
   local CHANNEL_NAME=$5
   local CA_CERT=\${6:-}
   local CHAINCODE_LABEL="\${CHANNEL_NAME}_\${CHAINCODE_NAME}_$CHAINCODE_VERSION"
+  local PEER_NAME="\${PEER_ADDRESS%:*}"
+
+  # Use peer-specific package if available (CCaaS), otherwise fall back to shared package
+  local PACKAGE_FILE="$CHAINCODE_LABEL.tar.gz"
+  if docker exec "$CLI_NAME" test -f "/var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" 2>/dev/null; then
+    PACKAGE_FILE="\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
+  fi
 
   echo "Installing chaincode $CHAINCODE_NAME..."
   inputLog "CHAINCODE_VERSION: $CHAINCODE_VERSION"
   inputLog "PEER_ADDRESS: $PEER_ADDRESS"
   inputLog "CHANNEL_NAME: $CHANNEL_NAME"
   inputLog "CHAINCODE_LABEL: $CHAINCODE_LABEL"
+  inputLog "PACKAGE_FILE: $PACKAGE_FILE"
   inputLog "CA_CERT: $CA_CERT"
 
   local CA_CERT_PARAMS=()
@@ -2909,7 +2918,7 @@ chaincodeInstall() {
   fi
 
   docker exec -e CORE_PEER_ADDRESS="$PEER_ADDRESS" "$CLI_NAME" peer lifecycle chaincode install \\
-    "/var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz" \\
+    "/var/hyperledger/cli/chaincode-packages/$PACKAGE_FILE" \\
     "\${CA_CERT_PARAMS[@]+"\${CA_CERT_PARAMS[@]}"}"
 }
 

--- a/e2e/__snapshots__/fablo-config-hlf2-2orgs-2chaincodes-private-data.yaml.test.ts.snap
+++ b/e2e/__snapshots__/fablo-config-hlf2-2orgs-2chaincodes-private-data.yaml.test.ts.snap
@@ -3595,6 +3595,7 @@ chaincodePackageCCaaS() {
   local CHANNEL_NAME=$9
   local ORG_DOMAIN=\${10}
   local CHAINCODE_LABEL="\${CHANNEL_NAME}_\${CHAINCODE_NAME}_$CHAINCODE_VERSION"
+  local PEER_NAME="\${PEER_ADDRESS%:*}"
 
   echo "Packaging CCaaS chaincode $CHAINCODE_NAME..."
   inputLog "CHAINCODE_VERSION: $CHAINCODE_VERSION"
@@ -3642,14 +3643,14 @@ chaincodePackageCCaaS() {
   fi
 
   tar -czf "$PACKAGE_DIR/code.tar.gz" -C "$PACKAGE_DIR/code" connection.json
-  tar -czf "./chaincode-packages/$CHAINCODE_LABEL.tar.gz" -C "$PACKAGE_DIR" metadata.json code.tar.gz
+  tar -czf "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" -C "$PACKAGE_DIR" metadata.json code.tar.gz
 
-  docker cp "./chaincode-packages/$CHAINCODE_LABEL.tar.gz" "$CLI_NAME:/var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  docker cp "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" "$CLI_NAME:/var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
 
-  rm "./chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  rm "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
   rm -rf "$PACKAGE_DIR"
 
-  echo "CCaaS package created at /var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  echo "CCaaS package created at /var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
 }
 
 chaincodeInstall() {
@@ -3660,12 +3661,20 @@ chaincodeInstall() {
   local CHANNEL_NAME=$5
   local CA_CERT=\${6:-}
   local CHAINCODE_LABEL="\${CHANNEL_NAME}_\${CHAINCODE_NAME}_$CHAINCODE_VERSION"
+  local PEER_NAME="\${PEER_ADDRESS%:*}"
+
+  # Use peer-specific package if available (CCaaS), otherwise fall back to shared package
+  local PACKAGE_FILE="$CHAINCODE_LABEL.tar.gz"
+  if docker exec "$CLI_NAME" test -f "/var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" 2>/dev/null; then
+    PACKAGE_FILE="\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
+  fi
 
   echo "Installing chaincode $CHAINCODE_NAME..."
   inputLog "CHAINCODE_VERSION: $CHAINCODE_VERSION"
   inputLog "PEER_ADDRESS: $PEER_ADDRESS"
   inputLog "CHANNEL_NAME: $CHANNEL_NAME"
   inputLog "CHAINCODE_LABEL: $CHAINCODE_LABEL"
+  inputLog "PACKAGE_FILE: $PACKAGE_FILE"
   inputLog "CA_CERT: $CA_CERT"
 
   local CA_CERT_PARAMS=()
@@ -3674,7 +3683,7 @@ chaincodeInstall() {
   fi
 
   docker exec -e CORE_PEER_ADDRESS="$PEER_ADDRESS" "$CLI_NAME" peer lifecycle chaincode install \\
-    "/var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz" \\
+    "/var/hyperledger/cli/chaincode-packages/$PACKAGE_FILE" \\
     "\${CA_CERT_PARAMS[@]+"\${CA_CERT_PARAMS[@]}"}"
 }
 

--- a/e2e/__snapshots__/fablo-config-hlf2-2orgs-2chaincodes-raft.yaml.test.ts.snap
+++ b/e2e/__snapshots__/fablo-config-hlf2-2orgs-2chaincodes-raft.yaml.test.ts.snap
@@ -5538,6 +5538,7 @@ chaincodePackageCCaaS() {
   local CHANNEL_NAME=$9
   local ORG_DOMAIN=\${10}
   local CHAINCODE_LABEL="\${CHANNEL_NAME}_\${CHAINCODE_NAME}_$CHAINCODE_VERSION"
+  local PEER_NAME="\${PEER_ADDRESS%:*}"
 
   echo "Packaging CCaaS chaincode $CHAINCODE_NAME..."
   inputLog "CHAINCODE_VERSION: $CHAINCODE_VERSION"
@@ -5585,14 +5586,14 @@ chaincodePackageCCaaS() {
   fi
 
   tar -czf "$PACKAGE_DIR/code.tar.gz" -C "$PACKAGE_DIR/code" connection.json
-  tar -czf "./chaincode-packages/$CHAINCODE_LABEL.tar.gz" -C "$PACKAGE_DIR" metadata.json code.tar.gz
+  tar -czf "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" -C "$PACKAGE_DIR" metadata.json code.tar.gz
 
-  docker cp "./chaincode-packages/$CHAINCODE_LABEL.tar.gz" "$CLI_NAME:/var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  docker cp "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" "$CLI_NAME:/var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
 
-  rm "./chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  rm "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
   rm -rf "$PACKAGE_DIR"
 
-  echo "CCaaS package created at /var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  echo "CCaaS package created at /var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
 }
 
 chaincodeInstall() {
@@ -5603,12 +5604,20 @@ chaincodeInstall() {
   local CHANNEL_NAME=$5
   local CA_CERT=\${6:-}
   local CHAINCODE_LABEL="\${CHANNEL_NAME}_\${CHAINCODE_NAME}_$CHAINCODE_VERSION"
+  local PEER_NAME="\${PEER_ADDRESS%:*}"
+
+  # Use peer-specific package if available (CCaaS), otherwise fall back to shared package
+  local PACKAGE_FILE="$CHAINCODE_LABEL.tar.gz"
+  if docker exec "$CLI_NAME" test -f "/var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" 2>/dev/null; then
+    PACKAGE_FILE="\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
+  fi
 
   echo "Installing chaincode $CHAINCODE_NAME..."
   inputLog "CHAINCODE_VERSION: $CHAINCODE_VERSION"
   inputLog "PEER_ADDRESS: $PEER_ADDRESS"
   inputLog "CHANNEL_NAME: $CHANNEL_NAME"
   inputLog "CHAINCODE_LABEL: $CHAINCODE_LABEL"
+  inputLog "PACKAGE_FILE: $PACKAGE_FILE"
   inputLog "CA_CERT: $CA_CERT"
 
   local CA_CERT_PARAMS=()
@@ -5617,7 +5626,7 @@ chaincodeInstall() {
   fi
 
   docker exec -e CORE_PEER_ADDRESS="$PEER_ADDRESS" "$CLI_NAME" peer lifecycle chaincode install \\
-    "/var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz" \\
+    "/var/hyperledger/cli/chaincode-packages/$PACKAGE_FILE" \\
     "\${CA_CERT_PARAMS[@]+"\${CA_CERT_PARAMS[@]}"}"
 }
 

--- a/e2e/__snapshots__/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json.test.ts.snap
+++ b/e2e/__snapshots__/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json.test.ts.snap
@@ -6122,6 +6122,7 @@ chaincodePackageCCaaS() {
   local CHANNEL_NAME=$9
   local ORG_DOMAIN=\${10}
   local CHAINCODE_LABEL="\${CHANNEL_NAME}_\${CHAINCODE_NAME}_$CHAINCODE_VERSION"
+  local PEER_NAME="\${PEER_ADDRESS%:*}"
 
   echo "Packaging CCaaS chaincode $CHAINCODE_NAME..."
   inputLog "CHAINCODE_VERSION: $CHAINCODE_VERSION"
@@ -6169,14 +6170,14 @@ chaincodePackageCCaaS() {
   fi
 
   tar -czf "$PACKAGE_DIR/code.tar.gz" -C "$PACKAGE_DIR/code" connection.json
-  tar -czf "./chaincode-packages/$CHAINCODE_LABEL.tar.gz" -C "$PACKAGE_DIR" metadata.json code.tar.gz
+  tar -czf "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" -C "$PACKAGE_DIR" metadata.json code.tar.gz
 
-  docker cp "./chaincode-packages/$CHAINCODE_LABEL.tar.gz" "$CLI_NAME:/var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  docker cp "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" "$CLI_NAME:/var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
 
-  rm "./chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  rm "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
   rm -rf "$PACKAGE_DIR"
 
-  echo "CCaaS package created at /var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  echo "CCaaS package created at /var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
 }
 
 chaincodeInstall() {
@@ -6187,12 +6188,20 @@ chaincodeInstall() {
   local CHANNEL_NAME=$5
   local CA_CERT=\${6:-}
   local CHAINCODE_LABEL="\${CHANNEL_NAME}_\${CHAINCODE_NAME}_$CHAINCODE_VERSION"
+  local PEER_NAME="\${PEER_ADDRESS%:*}"
+
+  # Use peer-specific package if available (CCaaS), otherwise fall back to shared package
+  local PACKAGE_FILE="$CHAINCODE_LABEL.tar.gz"
+  if docker exec "$CLI_NAME" test -f "/var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" 2>/dev/null; then
+    PACKAGE_FILE="\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
+  fi
 
   echo "Installing chaincode $CHAINCODE_NAME..."
   inputLog "CHAINCODE_VERSION: $CHAINCODE_VERSION"
   inputLog "PEER_ADDRESS: $PEER_ADDRESS"
   inputLog "CHANNEL_NAME: $CHANNEL_NAME"
   inputLog "CHAINCODE_LABEL: $CHAINCODE_LABEL"
+  inputLog "PACKAGE_FILE: $PACKAGE_FILE"
   inputLog "CA_CERT: $CA_CERT"
 
   local CA_CERT_PARAMS=()
@@ -6201,7 +6210,7 @@ chaincodeInstall() {
   fi
 
   docker exec -e CORE_PEER_ADDRESS="$PEER_ADDRESS" "$CLI_NAME" peer lifecycle chaincode install \\
-    "/var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz" \\
+    "/var/hyperledger/cli/chaincode-packages/$PACKAGE_FILE" \\
     "\${CA_CERT_PARAMS[@]+"\${CA_CERT_PARAMS[@]}"}"
 }
 

--- a/e2e/__snapshots__/fablo-config-hlf3-1orgs-2chaincodes.json.test.ts.snap
+++ b/e2e/__snapshots__/fablo-config-hlf3-1orgs-2chaincodes.json.test.ts.snap
@@ -3111,6 +3111,7 @@ chaincodePackageCCaaS() {
   local CHANNEL_NAME=$9
   local ORG_DOMAIN=\${10}
   local CHAINCODE_LABEL="\${CHANNEL_NAME}_\${CHAINCODE_NAME}_$CHAINCODE_VERSION"
+  local PEER_NAME="\${PEER_ADDRESS%:*}"
 
   echo "Packaging CCaaS chaincode $CHAINCODE_NAME..."
   inputLog "CHAINCODE_VERSION: $CHAINCODE_VERSION"
@@ -3158,14 +3159,14 @@ chaincodePackageCCaaS() {
   fi
 
   tar -czf "$PACKAGE_DIR/code.tar.gz" -C "$PACKAGE_DIR/code" connection.json
-  tar -czf "./chaincode-packages/$CHAINCODE_LABEL.tar.gz" -C "$PACKAGE_DIR" metadata.json code.tar.gz
+  tar -czf "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" -C "$PACKAGE_DIR" metadata.json code.tar.gz
 
-  docker cp "./chaincode-packages/$CHAINCODE_LABEL.tar.gz" "$CLI_NAME:/var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  docker cp "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" "$CLI_NAME:/var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
 
-  rm "./chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  rm "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
   rm -rf "$PACKAGE_DIR"
 
-  echo "CCaaS package created at /var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  echo "CCaaS package created at /var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
 }
 
 chaincodeInstall() {
@@ -3176,12 +3177,20 @@ chaincodeInstall() {
   local CHANNEL_NAME=$5
   local CA_CERT=\${6:-}
   local CHAINCODE_LABEL="\${CHANNEL_NAME}_\${CHAINCODE_NAME}_$CHAINCODE_VERSION"
+  local PEER_NAME="\${PEER_ADDRESS%:*}"
+
+  # Use peer-specific package if available (CCaaS), otherwise fall back to shared package
+  local PACKAGE_FILE="$CHAINCODE_LABEL.tar.gz"
+  if docker exec "$CLI_NAME" test -f "/var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" 2>/dev/null; then
+    PACKAGE_FILE="\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
+  fi
 
   echo "Installing chaincode $CHAINCODE_NAME..."
   inputLog "CHAINCODE_VERSION: $CHAINCODE_VERSION"
   inputLog "PEER_ADDRESS: $PEER_ADDRESS"
   inputLog "CHANNEL_NAME: $CHANNEL_NAME"
   inputLog "CHAINCODE_LABEL: $CHAINCODE_LABEL"
+  inputLog "PACKAGE_FILE: $PACKAGE_FILE"
   inputLog "CA_CERT: $CA_CERT"
 
   local CA_CERT_PARAMS=()
@@ -3190,7 +3199,7 @@ chaincodeInstall() {
   fi
 
   docker exec -e CORE_PEER_ADDRESS="$PEER_ADDRESS" "$CLI_NAME" peer lifecycle chaincode install \\
-    "/var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz" \\
+    "/var/hyperledger/cli/chaincode-packages/$PACKAGE_FILE" \\
     "\${CA_CERT_PARAMS[@]+"\${CA_CERT_PARAMS[@]}"}"
 }
 

--- a/e2e/__snapshots__/fablo-config-hlf3-2orgs-1chaincode-raft-ccaas.test.ts.snap
+++ b/e2e/__snapshots__/fablo-config-hlf3-2orgs-1chaincode-raft-ccaas.test.ts.snap
@@ -3680,6 +3680,7 @@ chaincodePackageCCaaS() {
   local CHANNEL_NAME=$9
   local ORG_DOMAIN=\${10}
   local CHAINCODE_LABEL="\${CHANNEL_NAME}_\${CHAINCODE_NAME}_$CHAINCODE_VERSION"
+  local PEER_NAME="\${PEER_ADDRESS%:*}"
 
   echo "Packaging CCaaS chaincode $CHAINCODE_NAME..."
   inputLog "CHAINCODE_VERSION: $CHAINCODE_VERSION"
@@ -3727,14 +3728,14 @@ chaincodePackageCCaaS() {
   fi
 
   tar -czf "$PACKAGE_DIR/code.tar.gz" -C "$PACKAGE_DIR/code" connection.json
-  tar -czf "./chaincode-packages/$CHAINCODE_LABEL.tar.gz" -C "$PACKAGE_DIR" metadata.json code.tar.gz
+  tar -czf "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" -C "$PACKAGE_DIR" metadata.json code.tar.gz
 
-  docker cp "./chaincode-packages/$CHAINCODE_LABEL.tar.gz" "$CLI_NAME:/var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  docker cp "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" "$CLI_NAME:/var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
 
-  rm "./chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  rm "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
   rm -rf "$PACKAGE_DIR"
 
-  echo "CCaaS package created at /var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  echo "CCaaS package created at /var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
 }
 
 chaincodeInstall() {
@@ -3745,12 +3746,20 @@ chaincodeInstall() {
   local CHANNEL_NAME=$5
   local CA_CERT=\${6:-}
   local CHAINCODE_LABEL="\${CHANNEL_NAME}_\${CHAINCODE_NAME}_$CHAINCODE_VERSION"
+  local PEER_NAME="\${PEER_ADDRESS%:*}"
+
+  # Use peer-specific package if available (CCaaS), otherwise fall back to shared package
+  local PACKAGE_FILE="$CHAINCODE_LABEL.tar.gz"
+  if docker exec "$CLI_NAME" test -f "/var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" 2>/dev/null; then
+    PACKAGE_FILE="\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
+  fi
 
   echo "Installing chaincode $CHAINCODE_NAME..."
   inputLog "CHAINCODE_VERSION: $CHAINCODE_VERSION"
   inputLog "PEER_ADDRESS: $PEER_ADDRESS"
   inputLog "CHANNEL_NAME: $CHANNEL_NAME"
   inputLog "CHAINCODE_LABEL: $CHAINCODE_LABEL"
+  inputLog "PACKAGE_FILE: $PACKAGE_FILE"
   inputLog "CA_CERT: $CA_CERT"
 
   local CA_CERT_PARAMS=()
@@ -3759,7 +3768,7 @@ chaincodeInstall() {
   fi
 
   docker exec -e CORE_PEER_ADDRESS="$PEER_ADDRESS" "$CLI_NAME" peer lifecycle chaincode install \\
-    "/var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz" \\
+    "/var/hyperledger/cli/chaincode-packages/$PACKAGE_FILE" \\
     "\${CA_CERT_PARAMS[@]+"\${CA_CERT_PARAMS[@]}"}"
 }
 

--- a/e2e/__snapshots__/fablo-config-hlf3-bft-1orgs-1chaincode.json.test.ts.snap
+++ b/e2e/__snapshots__/fablo-config-hlf3-bft-1orgs-1chaincode.json.test.ts.snap
@@ -3063,6 +3063,7 @@ chaincodePackageCCaaS() {
   local CHANNEL_NAME=$9
   local ORG_DOMAIN=\${10}
   local CHAINCODE_LABEL="\${CHANNEL_NAME}_\${CHAINCODE_NAME}_$CHAINCODE_VERSION"
+  local PEER_NAME="\${PEER_ADDRESS%:*}"
 
   echo "Packaging CCaaS chaincode $CHAINCODE_NAME..."
   inputLog "CHAINCODE_VERSION: $CHAINCODE_VERSION"
@@ -3110,14 +3111,14 @@ chaincodePackageCCaaS() {
   fi
 
   tar -czf "$PACKAGE_DIR/code.tar.gz" -C "$PACKAGE_DIR/code" connection.json
-  tar -czf "./chaincode-packages/$CHAINCODE_LABEL.tar.gz" -C "$PACKAGE_DIR" metadata.json code.tar.gz
+  tar -czf "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" -C "$PACKAGE_DIR" metadata.json code.tar.gz
 
-  docker cp "./chaincode-packages/$CHAINCODE_LABEL.tar.gz" "$CLI_NAME:/var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  docker cp "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" "$CLI_NAME:/var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
 
-  rm "./chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  rm "./chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
   rm -rf "$PACKAGE_DIR"
 
-  echo "CCaaS package created at /var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  echo "CCaaS package created at /var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
 }
 
 chaincodeInstall() {
@@ -3128,12 +3129,20 @@ chaincodeInstall() {
   local CHANNEL_NAME=$5
   local CA_CERT=\${6:-}
   local CHAINCODE_LABEL="\${CHANNEL_NAME}_\${CHAINCODE_NAME}_$CHAINCODE_VERSION"
+  local PEER_NAME="\${PEER_ADDRESS%:*}"
+
+  # Use peer-specific package if available (CCaaS), otherwise fall back to shared package
+  local PACKAGE_FILE="$CHAINCODE_LABEL.tar.gz"
+  if docker exec "$CLI_NAME" test -f "/var/hyperledger/cli/chaincode-packages/\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz" 2>/dev/null; then
+    PACKAGE_FILE="\${CHAINCODE_LABEL}_\${PEER_NAME}.tar.gz"
+  fi
 
   echo "Installing chaincode $CHAINCODE_NAME..."
   inputLog "CHAINCODE_VERSION: $CHAINCODE_VERSION"
   inputLog "PEER_ADDRESS: $PEER_ADDRESS"
   inputLog "CHANNEL_NAME: $CHANNEL_NAME"
   inputLog "CHAINCODE_LABEL: $CHAINCODE_LABEL"
+  inputLog "PACKAGE_FILE: $PACKAGE_FILE"
   inputLog "CA_CERT: $CA_CERT"
 
   local CA_CERT_PARAMS=()
@@ -3142,7 +3151,7 @@ chaincodeInstall() {
   fi
 
   docker exec -e CORE_PEER_ADDRESS="$PEER_ADDRESS" "$CLI_NAME" peer lifecycle chaincode install \\
-    "/var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz" \\
+    "/var/hyperledger/cli/chaincode-packages/$PACKAGE_FILE" \\
     "\${CA_CERT_PARAMS[@]+"\${CA_CERT_PARAMS[@]}"}"
 }
 

--- a/src/setup-docker/templates/fabric-docker/scripts/chaincode-functions-v2.sh
+++ b/src/setup-docker/templates/fabric-docker/scripts/chaincode-functions-v2.sh
@@ -114,6 +114,7 @@ chaincodePackageCCaaS() {
   local CHANNEL_NAME=$9
   local ORG_DOMAIN=${10}
   local CHAINCODE_LABEL="${CHANNEL_NAME}_${CHAINCODE_NAME}_$CHAINCODE_VERSION"
+  local PEER_NAME="${PEER_ADDRESS%:*}"
 
   echo "Packaging CCaaS chaincode $CHAINCODE_NAME..."
   inputLog "CHAINCODE_VERSION: $CHAINCODE_VERSION"
@@ -162,14 +163,14 @@ chaincodePackageCCaaS() {
   fi
 
   tar -czf "$PACKAGE_DIR/code.tar.gz" -C "$PACKAGE_DIR/code" connection.json
-  tar -czf "./chaincode-packages/$CHAINCODE_LABEL.tar.gz" -C "$PACKAGE_DIR" metadata.json code.tar.gz
+  tar -czf "./chaincode-packages/${CHAINCODE_LABEL}_${PEER_NAME}.tar.gz" -C "$PACKAGE_DIR" metadata.json code.tar.gz
 
-  docker cp "./chaincode-packages/$CHAINCODE_LABEL.tar.gz" "$CLI_NAME:/var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  docker cp "./chaincode-packages/${CHAINCODE_LABEL}_${PEER_NAME}.tar.gz" "$CLI_NAME:/var/hyperledger/cli/chaincode-packages/${CHAINCODE_LABEL}_${PEER_NAME}.tar.gz"
 
-  rm "./chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  rm "./chaincode-packages/${CHAINCODE_LABEL}_${PEER_NAME}.tar.gz"
   rm -rf "$PACKAGE_DIR"
 
-  echo "CCaaS package created at /var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz"
+  echo "CCaaS package created at /var/hyperledger/cli/chaincode-packages/${CHAINCODE_LABEL}_${PEER_NAME}.tar.gz"
 }
 
 chaincodeInstall() {
@@ -180,12 +181,20 @@ chaincodeInstall() {
   local CHANNEL_NAME=$5
   local CA_CERT=${6:-}
   local CHAINCODE_LABEL="${CHANNEL_NAME}_${CHAINCODE_NAME}_$CHAINCODE_VERSION"
+  local PEER_NAME="${PEER_ADDRESS%:*}"
+
+  # Use peer-specific package if available (CCaaS), otherwise fall back to shared package
+  local PACKAGE_FILE="$CHAINCODE_LABEL.tar.gz"
+  if docker exec "$CLI_NAME" test -f "/var/hyperledger/cli/chaincode-packages/${CHAINCODE_LABEL}_${PEER_NAME}.tar.gz" 2>/dev/null; then
+    PACKAGE_FILE="${CHAINCODE_LABEL}_${PEER_NAME}.tar.gz"
+  fi
 
   echo "Installing chaincode $CHAINCODE_NAME..."
   inputLog "CHAINCODE_VERSION: $CHAINCODE_VERSION"
   inputLog "PEER_ADDRESS: $PEER_ADDRESS"
   inputLog "CHANNEL_NAME: $CHANNEL_NAME"
   inputLog "CHAINCODE_LABEL: $CHAINCODE_LABEL"
+  inputLog "PACKAGE_FILE: $PACKAGE_FILE"
   inputLog "CA_CERT: $CA_CERT"
 
   local CA_CERT_PARAMS=()
@@ -194,7 +203,7 @@ chaincodeInstall() {
   fi
 
   docker exec -e CORE_PEER_ADDRESS="$PEER_ADDRESS" "$CLI_NAME" peer lifecycle chaincode install \
-    "/var/hyperledger/cli/chaincode-packages/$CHAINCODE_LABEL.tar.gz" \
+    "/var/hyperledger/cli/chaincode-packages/$PACKAGE_FILE" \
     "${CA_CERT_PARAMS[@]+"${CA_CERT_PARAMS[@]}"}"
 }
 


### PR DESCRIPTION
In CCaaS setups with multiple peers, the chaincode connection package ($CHAINCODE_LABEL.tar.gz) was being overwritten during the packaging loop because the filename didn't include the peer name. This caused all peers to install the last package, routing all chaincode requests to the last CCaaS container.

Changes:
- chaincodePackageCCaaS(): archive name now includes peer name (${CHAINCODE_LABEL}_${PEER_NAME}.tar.gz)
- chaincodeInstall(): detects peer-specific package if available, falls back to shared package for non-CCaaS chaincodes

TLS support is fully preserved.

Fixes #653