### PR TITLE
fix: select v3 chaincode-functions template for Fabric v3 networks

### DIFF
--- a/src/setup-docker/index.ts
+++ b/src/setup-docker/index.ts
@@ -276,10 +276,10 @@ export default class SetupDocker extends Command {
     const baseHelpDest = getDestinationPath(this.outputDir, "fabric-docker/scripts/base-help.sh");
     await renderTemplate(baseHelpTemplate, baseHelpDest, {});
 
-    // Copy chaincode-functions script
+    // Copy chaincode-functions script (v2 or v3)
     const chaincodeFunctionsTemplate = getTemplatePath(
       this.templatesDir,
-      `fabric-docker/scripts/chaincode-functions-${capabilities.isV2 ? "v2" : "v2"}.sh`,
+      `fabric-docker/scripts/chaincode-functions-${capabilities.isV3 ? "v3" : "v2"}.sh`,
     );
     const chaincodeFunctionsDest = getDestinationPath(this.outputDir, "fabric-docker/scripts/chaincode-functions.sh");
     await renderTemplate(chaincodeFunctionsTemplate, chaincodeFunctionsDest, {});


### PR DESCRIPTION
## Description
This PR fixes a critical bug where Docker-based Fabric v3 networks were incorrectly receiving the `v2` version of the `chaincode-functions.sh` lifecycle script instead of `v3`.

## Root Cause
In `src/setup-docker/index.ts`, the ternary operator selecting the script template was hardcoded to return `"v2"` in both branches:

```typescript
`fabric-docker/scripts/chaincode-functions-${capabilities.isV2 ? "v2" : "v2"}.sh`
```

This effectively resulted in dead code for v3 support.

## Proposed Changes
- Updated the ternary expression to correctly branch out: `capabilities.isV3 ? "v3" : "v2"`
- This aligns the `chaincode-functions.sh` template selection with how `channel_fns` and `base-functions` are successfully handling v3 conditions in the same file.

## Impact
Fabric v3 configurations will now properly inherit the `v3` chaincode lifecycle functions, preventing unhandled behaviors or crashes during chaincode setup/operations.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [ ] Added unit tests
- [ ] Added e2e tests
- [x] Manual testing with Fabric v3 network configuration
- [ ] Existing tests pass

## Checklist
- [x] Code follows project conventions
- [x] Commit messages are clear
- [x] All tests pass locally
- [ ] Updated documentation (if applicable)

---

### Code Changes

**src/setup-docker/index.ts**
```diff
- `fabric-docker/scripts/chaincode-functions-${capabilities.isV2 ? "v2" : "v2"}.sh`
+ `fabric-docker/scripts/chaincode-functions-${capabilities.isV3 ? "v3" : "v2"}.sh`
```

Closes #704 