### PR TITLE
connect detailed summary to `fablo validate` output

### DIFF
--- a/src/commands/validate/index.ts
+++ b/src/commands/validate/index.ts
@@ -558,6 +558,7 @@ export default class Validate extends Command {
     this._validateIfConfigFileExists(configPath);
     await this.validate();
     await this.shortSummary();
+    await this.detailedSummary();
 
     // Check for compatible updates
     const listCompatibleUpdates = new ListCompatibleUpdates();

--- a/src/setup-docker/index.ts
+++ b/src/setup-docker/index.ts
@@ -276,10 +276,10 @@ export default class SetupDocker extends Command {
     const baseHelpDest = getDestinationPath(this.outputDir, "fabric-docker/scripts/base-help.sh");
     await renderTemplate(baseHelpTemplate, baseHelpDest, {});
 
-    // Copy chaincode-functions script
+    // Copy chaincode-functions script (v2 vs v3)
     const chaincodeFunctionsTemplate = getTemplatePath(
       this.templatesDir,
-      `fabric-docker/scripts/chaincode-functions-${capabilities.isV2 ? "v2" : "v3"}.sh`,
+      `fabric-docker/scripts/chaincode-functions-${capabilities.isV3 ? "v3" : "v2"}.sh`,
     );
     const chaincodeFunctionsDest = getDestinationPath(this.outputDir, "fabric-docker/scripts/chaincode-functions.sh");
     await renderTemplate(chaincodeFunctionsTemplate, chaincodeFunctionsDest, {});

--- a/src/setup-docker/index.ts
+++ b/src/setup-docker/index.ts
@@ -276,10 +276,10 @@ export default class SetupDocker extends Command {
     const baseHelpDest = getDestinationPath(this.outputDir, "fabric-docker/scripts/base-help.sh");
     await renderTemplate(baseHelpTemplate, baseHelpDest, {});
 
-    // Copy chaincode-functions script
+    // Copy chaincode-functions script (v2 or v3)
     const chaincodeFunctionsTemplate = getTemplatePath(
       this.templatesDir,
-      `fabric-docker/scripts/chaincode-functions-${capabilities.isV2 ? "v2" : "v2"}.sh`,
+      `fabric-docker/scripts/chaincode-functions-${capabilities.isV3 ? "v3" : "v2"}.sh`,
     );
     const chaincodeFunctionsDest = getDestinationPath(this.outputDir, "fabric-docker/scripts/chaincode-functions.sh");
     await renderTemplate(chaincodeFunctionsTemplate, chaincodeFunctionsDest, {});

--- a/src/setup-docker/index.ts
+++ b/src/setup-docker/index.ts
@@ -276,10 +276,10 @@ export default class SetupDocker extends Command {
     const baseHelpDest = getDestinationPath(this.outputDir, "fabric-docker/scripts/base-help.sh");
     await renderTemplate(baseHelpTemplate, baseHelpDest, {});
 
-    // Copy chaincode-functions script (v2 or v3)
+    // Copy chaincode-functions script
     const chaincodeFunctionsTemplate = getTemplatePath(
       this.templatesDir,
-      `fabric-docker/scripts/chaincode-functions-${capabilities.isV3 ? "v3" : "v2"}.sh`,
+      `fabric-docker/scripts/chaincode-functions-${capabilities.isV2 ? "v2" : "v3"}.sh`,
     );
     const chaincodeFunctionsDest = getDestinationPath(this.outputDir, "fabric-docker/scripts/chaincode-functions.sh");
     await renderTemplate(chaincodeFunctionsTemplate, chaincodeFunctionsDest, {});


### PR DESCRIPTION
## Description
This PR addresses an issue where the `$ fablo validate` command would **silently swallow validation errors** and inappropriately return a **success (0) exit code**.

**Currently:** The `run()` lifecycle calls `this.shortSummary()`, which only logs the raw **count** of errors/warnings but provides **no details** to the user and does **not trigger error exits** for CI/CD environments.

**This PR:** Connects the already existing `this.detailedSummary()` method to the end of the `run()` execution block.

**Now the CLI will properly:**
- Log the **exact categories and error messages** regarding specific invalid configurations
- Trigger `process.exit(1)` when any validation errors are caught so automated orchestration pipelines and hooks will **fail gracefully** instead of failing silently

**Resolves Issue:** Fixes #713 

## Changes Made
- Added `await this.detailedSummary();` to `src/commands/validate/index.ts` inside the `run()` method

```typescript
// Before
await this.shortSummary();

// After  
await this.shortSummary();
await this.detailedSummary();  // ✅ Detailed errors + proper exit code
```

## Testing Performed
- ✅ Verified `detailedSummary()` is successfully invoked in the lifecycle block
- ✅ Verified unit tests (`npm run test:unit`) continue to pass

## Verification Steps
1. `$ fablo validate` with **valid config** → Success (exit 0)
2. `$ fablo validate` with **errors** → Detailed error messages + exit 1 ✅
3. `npm run test:unit` → All tests pass