### PR TITLE
feat(ci): add manual version bump workflow with PR automation

### DIFF
--- a/.github/workflows/create-bump-version-pr.yml
+++ b/.github/workflows/create-bump-version-pr.yml
@@ -35,16 +35,19 @@ jobs:
           npm install -g oclif
 
       - name: Run bump-version.sh
+        env:
+          BUMP_ARG_ENV: ${{ github.event.inputs.version }}
         run: |
           set -e
-          BUMP_ARG="${{ github.event.inputs.version }}"
-
+          BUMP_ARG="$BUMP_ARG_ENV"
           if [[ "$BUMP_ARG" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
             ./bump-version.sh set "$BUMP_ARG"
-          elif [[ "$BUMP_ARG" =~ ^set[[:space:]]+[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
-            ./bump-version.sh $BUMP_ARG
-          else
+          elif [[ "$BUMP_ARG" =~ ^(patch|minor|major|unstable)$ ]]; then
             ./bump-version.sh "$BUMP_ARG"
+          else
+            echo "::error::Invalid version input"
+            echo "Allowed values: patch, minor, major, unstable, or a valid semver (e.g. 1.2.3)."
+            exit 1
           fi
 
       - name: Get version

--- a/.github/workflows/create-bump-version-pr.yml
+++ b/.github/workflows/create-bump-version-pr.yml
@@ -1,0 +1,66 @@
+name: Create Bump Version PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version bump (patch, minor, major, unstable, or set 1.2.3)'
+        required: true
+        default: 'patch'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          npm install -g semver 
+          npm install -g oclif
+
+      - name: Run bump-version.sh
+        run: |
+          set -e
+          BUMP_ARG="${{ github.event.inputs.version }}"
+
+          if [[ "$BUMP_ARG" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
+            ./bump-version.sh set "$BUMP_ARG"
+          elif [[ "$BUMP_ARG" =~ ^set[[:space:]]+[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
+            ./bump-version.sh $BUMP_ARG
+          else
+            ./bump-version.sh "$BUMP_ARG"
+          fi
+
+      - name: Get version
+        id: package-version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Bump version to ${{ steps.package-version.outputs.version }}"
+          title: "Bump version to ${{ steps.package-version.outputs.version }}"
+          body: "This PR bumps the version of Fablo to ${{ steps.package-version.outputs.version }} using the manual workflow."
+          branch: "bump-version-${{ steps.package-version.outputs.version }}-${{ github.run_id }}"
+          base: main
+          labels: bump-version-pr
+          delete-branch: true


### PR DESCRIPTION
##  Description

This PR introduces a manual GitHub Actions workflow to automate version bumping and PR creation.
### Fixes: #606

##  Features

- Manual trigger via `workflow_dispatch`
- Supports:
  - patch
  - minor
  - major
  - custom versions (e.g. 1.2.3)
- Automatically:
  - updates version
  - creates a new branch
  - opens a Pull Request
##  How to test

1. Go to Actions → "Create Bump Version PR"
2. Click "Run workflow"
3. Enter a version input (e.g. `patch`)
4. Verify PR is created

##  Outcome 
<img width="922" height="557" alt="image" src="https://github.com/user-attachments/assets/82972576-ca7b-4fb2-8ff1-8026cbfc23cc" />
<img width="918" height="772" alt="image" src="https://github.com/user-attachments/assets/206206c9-57e2-4c55-aaf8-3db62e0ae575" />


This enables a clean release workflow:
manual trigger → version bump PR → merge → publish pipeline 🚀