### PR TITLE
Fix: add missing "mysql" option to CAJson.db TypeScript type

### DIFF
--- a/src/types/FabloConfigExtended.ts
+++ b/src/types/FabloConfigExtended.ts
@@ -74,7 +74,7 @@ export interface CAConfig {
   fullAddress: string;
   port: number;
   prefix: string;
-  db: "sqlite" | "postgres";
+  db: "sqlite" | "postgres" | "mysql";
 }
 
 export interface PeerConfig {

--- a/src/types/FabloConfigJson.ts
+++ b/src/types/FabloConfigJson.ts
@@ -27,7 +27,7 @@ export interface OrganizationDetailsJson {
 
 export interface CAJson {
   prefix: string;
-  db: "sqlite" | "postgres";
+  db: "sqlite" | "postgres" | "mysql";
 }
 
 export interface OrdererJson {


### PR DESCRIPTION
### What (Fixes #722)

The `CAJson.db` type in `src/types/FabloConfigJson.ts` (line 30) is missing the `"mysql"` option.

MySQL CA database support already exists in:
- `docs/schema.json` (line 239 – `"mysql"` in enum)
- Docker-compose template (lines 23, 25, 40, 66 – `org.ca.db === "mysql"`)
- `snapshot-scripts.sh` (`__getCAMySQLNodes`)

But the TypeScript type only allows `"sqlite" | "postgres"`.

### Fix

```typescript
// Before:
db: "sqlite" | "postgres";

// After:
db: "sqlite" | "postgres" | "mysql";
```
