### PR TITLE
Fix: correct YAML indentation for per-org Explorer service in docker-compose template

### DIFF
--- a/src/setup-docker/templates/fabric-docker/docker-compose.yaml
+++ b/src/setup-docker/templates/fabric-docker/docker-compose.yaml
@@ -183,7 +183,7 @@ services:
       - basic
 
   <%= org.tools.explorer.address %>:
-  image: ghcr.io/hyperledger-labs/explorer:${HYPERLEDGER_EXPLORER_VERSION}
+    image: ghcr.io/hyperledger-labs/explorer:${HYPERLEDGER_EXPLORER_VERSION}
     restart: on-failure:8
     container_name: <%= org.tools.explorer.address %>
     environment:


### PR DESCRIPTION
### What

The per-org Explorer service block in the docker-compose template (line 186) has `image:` with only 2 spaces of indentation – the same level as the service name. It should have 4 spaces to be a child property of the service.

| Before (broken) | After (fixed) |
|---|---|
| <img width="564" height="192" alt="Screenshot 2026-04-19 002907" src="https://github.com/user-attachments/assets/bf4dbce1-cdbf-40fc-a9cf-85a751875ce7" /> | <img width="576" height="396" alt="Screenshot 2026-04-19 002931" src="https://github.com/user-attachments/assets/a708b9f2-9ac0-4c8a-a6ec-7a9a35efe823" /> |

```yaml
# Before (line 185-187 – broken):
  <%= org.tools.explorer.address %>:
  image: ghcr.io/hyperledger-labs/explorer:${HYPERLEDGER_EXPLORER_VERSION}
    restart: on-failure:8

# After (fixed):
  <%= org.tools.explorer.address %>:
    image: ghcr.io/hyperledger-labs/explorer:${HYPERLEDGER_EXPLORER_VERSION}
    restart: on-failure:8
```

The global Explorer block (line 379-380) already has the correct 4-space indentation.

### Impact

Generated `docker-compose` YAML is syntactically invalid when per-org Explorer is enabled, causing `docker compose up` to fail with a parse error.

Fixes #727