### PR TITLE
Fix: correct orderer TLS path in ConnectionProfile

### DIFF
--- a/e2e/__snapshots__/fablo-config-hlf2-1org-2chaincode-raft-ccaas.json.test.ts.snap
+++ b/e2e/__snapshots__/fablo-config-hlf2-1org-2chaincode-raft-ccaas.json.test.ts.snap
@@ -323,7 +323,7 @@ exports[`samples/fablo-config-hlf3-1org-2chaincode-raft-ccaas.json should create
     "orderer0.group1.orderer.example.com": {
       "url": "grpcs://localhost:7030",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.orderer.example.com"
@@ -369,7 +369,7 @@ orderers:
     url: grpcs://localhost:7030
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.orderer.example.com
 "
@@ -421,7 +421,7 @@ exports[`samples/fablo-config-hlf3-1org-2chaincode-raft-ccaas.json should create
     "orderer0.group1.orderer.example.com": {
       "url": "grpcs://localhost:7030",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.orderer.example.com"
@@ -475,7 +475,7 @@ orderers:
     url: grpcs://localhost:7030
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.orderer.example.com
 channels:

--- a/e2e/__snapshots__/fablo-config-hlf2-2orgs-2chaincodes-raft.yaml.test.ts.snap
+++ b/e2e/__snapshots__/fablo-config-hlf2-2orgs-2chaincodes-raft.yaml.test.ts.snap
@@ -508,7 +508,7 @@ exports[`samples/fablo-config-hlf2-2orgs-2chaincodes-raft.yaml should create pro
     "orderer0.group1.orderer1.com": {
       "url": "grpcs://localhost:7030",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer1.com/orderers/orderer0.group1.orderer1.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer1.com/peers/orderer0.group1.orderer1.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.orderer1.com"
@@ -517,7 +517,7 @@ exports[`samples/fablo-config-hlf2-2orgs-2chaincodes-raft.yaml should create pro
     "orderer1.group1.orderer1.com": {
       "url": "grpcs://localhost:7031",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer1.com/orderers/orderer1.group1.orderer1.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer1.com/peers/orderer1.group1.orderer1.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer1.group1.orderer1.com"
@@ -526,7 +526,7 @@ exports[`samples/fablo-config-hlf2-2orgs-2chaincodes-raft.yaml should create pro
     "orderer2.group1.orderer1.com": {
       "url": "grpcs://localhost:7032",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer1.com/orderers/orderer2.group1.orderer1.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer1.com/peers/orderer2.group1.orderer1.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer2.group1.orderer1.com"
@@ -535,7 +535,7 @@ exports[`samples/fablo-config-hlf2-2orgs-2chaincodes-raft.yaml should create pro
     "orderer0.group2.orderer2.com": {
       "url": "grpcs://localhost:7050",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer2.com/orderers/orderer0.group2.orderer2.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer2.com/peers/orderer0.group2.orderer2.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group2.orderer2.com"
@@ -605,28 +605,28 @@ orderers:
     url: grpcs://localhost:7030
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer1.com/orderers/orderer0.group1.orderer1.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer1.com/peers/orderer0.group1.orderer1.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.orderer1.com
   orderer1.group1.orderer1.com:
     url: grpcs://localhost:7031
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer1.com/orderers/orderer1.group1.orderer1.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer1.com/peers/orderer1.group1.orderer1.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer1.group1.orderer1.com
   orderer2.group1.orderer1.com:
     url: grpcs://localhost:7032
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer1.com/orderers/orderer2.group1.orderer1.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer1.com/peers/orderer2.group1.orderer1.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer2.group1.orderer1.com
   orderer0.group2.orderer2.com:
     url: grpcs://localhost:7050
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer2.com/orderers/orderer0.group2.orderer2.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer2.com/peers/orderer0.group2.orderer2.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group2.orderer2.com
 "
@@ -708,7 +708,7 @@ exports[`samples/fablo-config-hlf2-2orgs-2chaincodes-raft.yaml should create pro
     "orderer0.group1.orderer1.com": {
       "url": "grpcs://localhost:7030",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer1.com/orderers/orderer0.group1.orderer1.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer1.com/peers/orderer0.group1.orderer1.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.orderer1.com"
@@ -717,7 +717,7 @@ exports[`samples/fablo-config-hlf2-2orgs-2chaincodes-raft.yaml should create pro
     "orderer1.group1.orderer1.com": {
       "url": "grpcs://localhost:7031",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer1.com/orderers/orderer1.group1.orderer1.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer1.com/peers/orderer1.group1.orderer1.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer1.group1.orderer1.com"
@@ -726,7 +726,7 @@ exports[`samples/fablo-config-hlf2-2orgs-2chaincodes-raft.yaml should create pro
     "orderer2.group1.orderer1.com": {
       "url": "grpcs://localhost:7032",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer1.com/orderers/orderer2.group1.orderer1.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer1.com/peers/orderer2.group1.orderer1.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer2.group1.orderer1.com"
@@ -735,7 +735,7 @@ exports[`samples/fablo-config-hlf2-2orgs-2chaincodes-raft.yaml should create pro
     "orderer0.group2.orderer2.com": {
       "url": "grpcs://localhost:7050",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer2.com/orderers/orderer0.group2.orderer2.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer2.com/peers/orderer0.group2.orderer2.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group2.orderer2.com"
@@ -805,28 +805,28 @@ orderers:
     url: grpcs://localhost:7030
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer1.com/orderers/orderer0.group1.orderer1.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer1.com/peers/orderer0.group1.orderer1.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.orderer1.com
   orderer1.group1.orderer1.com:
     url: grpcs://localhost:7031
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer1.com/orderers/orderer1.group1.orderer1.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer1.com/peers/orderer1.group1.orderer1.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer1.group1.orderer1.com
   orderer2.group1.orderer1.com:
     url: grpcs://localhost:7032
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer1.com/orderers/orderer2.group1.orderer1.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer1.com/peers/orderer2.group1.orderer1.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer2.group1.orderer1.com
   orderer0.group2.orderer2.com:
     url: grpcs://localhost:7050
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer2.com/orderers/orderer0.group2.orderer2.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer2.com/peers/orderer0.group2.orderer2.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group2.orderer2.com
 "
@@ -908,7 +908,7 @@ exports[`samples/fablo-config-hlf2-2orgs-2chaincodes-raft.yaml should create pro
     "orderer0.group1.orderer1.com": {
       "url": "grpcs://localhost:7030",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer1.com/orderers/orderer0.group1.orderer1.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer1.com/peers/orderer0.group1.orderer1.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.orderer1.com"
@@ -917,7 +917,7 @@ exports[`samples/fablo-config-hlf2-2orgs-2chaincodes-raft.yaml should create pro
     "orderer1.group1.orderer1.com": {
       "url": "grpcs://localhost:7031",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer1.com/orderers/orderer1.group1.orderer1.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer1.com/peers/orderer1.group1.orderer1.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer1.group1.orderer1.com"
@@ -926,7 +926,7 @@ exports[`samples/fablo-config-hlf2-2orgs-2chaincodes-raft.yaml should create pro
     "orderer2.group1.orderer1.com": {
       "url": "grpcs://localhost:7032",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer1.com/orderers/orderer2.group1.orderer1.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer1.com/peers/orderer2.group1.orderer1.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer2.group1.orderer1.com"
@@ -935,7 +935,7 @@ exports[`samples/fablo-config-hlf2-2orgs-2chaincodes-raft.yaml should create pro
     "orderer0.group2.orderer2.com": {
       "url": "grpcs://localhost:7050",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer2.com/orderers/orderer0.group2.orderer2.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer2.com/peers/orderer0.group2.orderer2.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group2.orderer2.com"
@@ -1016,28 +1016,28 @@ orderers:
     url: grpcs://localhost:7030
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer1.com/orderers/orderer0.group1.orderer1.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer1.com/peers/orderer0.group1.orderer1.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.orderer1.com
   orderer1.group1.orderer1.com:
     url: grpcs://localhost:7031
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer1.com/orderers/orderer1.group1.orderer1.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer1.com/peers/orderer1.group1.orderer1.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer1.group1.orderer1.com
   orderer2.group1.orderer1.com:
     url: grpcs://localhost:7032
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer1.com/orderers/orderer2.group1.orderer1.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer1.com/peers/orderer2.group1.orderer1.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer2.group1.orderer1.com
   orderer0.group2.orderer2.com:
     url: grpcs://localhost:7050
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer2.com/orderers/orderer0.group2.orderer2.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer2.com/peers/orderer0.group2.orderer2.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group2.orderer2.com
 channels:
@@ -1126,7 +1126,7 @@ exports[`samples/fablo-config-hlf2-2orgs-2chaincodes-raft.yaml should create pro
     "orderer0.group1.orderer1.com": {
       "url": "grpcs://localhost:7030",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer1.com/orderers/orderer0.group1.orderer1.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer1.com/peers/orderer0.group1.orderer1.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.orderer1.com"
@@ -1135,7 +1135,7 @@ exports[`samples/fablo-config-hlf2-2orgs-2chaincodes-raft.yaml should create pro
     "orderer1.group1.orderer1.com": {
       "url": "grpcs://localhost:7031",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer1.com/orderers/orderer1.group1.orderer1.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer1.com/peers/orderer1.group1.orderer1.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer1.group1.orderer1.com"
@@ -1144,7 +1144,7 @@ exports[`samples/fablo-config-hlf2-2orgs-2chaincodes-raft.yaml should create pro
     "orderer2.group1.orderer1.com": {
       "url": "grpcs://localhost:7032",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer1.com/orderers/orderer2.group1.orderer1.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer1.com/peers/orderer2.group1.orderer1.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer2.group1.orderer1.com"
@@ -1153,7 +1153,7 @@ exports[`samples/fablo-config-hlf2-2orgs-2chaincodes-raft.yaml should create pro
     "orderer0.group2.orderer2.com": {
       "url": "grpcs://localhost:7050",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer2.com/orderers/orderer0.group2.orderer2.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer2.com/peers/orderer0.group2.orderer2.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group2.orderer2.com"
@@ -1234,28 +1234,28 @@ orderers:
     url: grpcs://localhost:7030
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer1.com/orderers/orderer0.group1.orderer1.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer1.com/peers/orderer0.group1.orderer1.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.orderer1.com
   orderer1.group1.orderer1.com:
     url: grpcs://localhost:7031
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer1.com/orderers/orderer1.group1.orderer1.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer1.com/peers/orderer1.group1.orderer1.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer1.group1.orderer1.com
   orderer2.group1.orderer1.com:
     url: grpcs://localhost:7032
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer1.com/orderers/orderer2.group1.orderer1.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer1.com/peers/orderer2.group1.orderer1.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer2.group1.orderer1.com
   orderer0.group2.orderer2.com:
     url: grpcs://localhost:7050
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer2.com/orderers/orderer0.group2.orderer2.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer2.com/peers/orderer0.group2.orderer2.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group2.orderer2.com
 channels:

--- a/e2e/__snapshots__/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json.test.ts.snap
+++ b/e2e/__snapshots__/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json.test.ts.snap
@@ -569,7 +569,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer0.group1.orderer.example.com": {
       "url": "grpcs://localhost:7030",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.orderer.example.com"
@@ -578,7 +578,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer1.group1.orderer.example.com": {
       "url": "grpcs://localhost:7031",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer1.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer1.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer1.group1.orderer.example.com"
@@ -587,7 +587,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer0.group1.org1.example.com": {
       "url": "grpcs://localhost:7050",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org1.example.com/orderers/orderer0.group1.org1.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/orderer0.group1.org1.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.org1.example.com"
@@ -596,7 +596,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer1.group1.org1.example.com": {
       "url": "grpcs://localhost:7051",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org1.example.com/orderers/orderer1.group1.org1.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/orderer1.group1.org1.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer1.group1.org1.example.com"
@@ -605,7 +605,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer0.group1.org2.example.com": {
       "url": "grpcs://localhost:7070",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org2.example.com/orderers/orderer0.group1.org2.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org2.example.com/peers/orderer0.group1.org2.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.org2.example.com"
@@ -614,7 +614,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer1.group1.org2.example.com": {
       "url": "grpcs://localhost:7071",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org2.example.com/orderers/orderer1.group1.org2.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org2.example.com/peers/orderer1.group1.org2.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer1.group1.org2.example.com"
@@ -623,7 +623,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer0.group1.org3.example.com": {
       "url": "grpcs://localhost:7090",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org3.example.com/orderers/orderer0.group1.org3.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org3.example.com/peers/orderer0.group1.org3.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.org3.example.com"
@@ -632,7 +632,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer1.group1.org3.example.com": {
       "url": "grpcs://localhost:7091",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org3.example.com/orderers/orderer1.group1.org3.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org3.example.com/peers/orderer1.group1.org3.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer1.group1.org3.example.com"
@@ -718,56 +718,56 @@ orderers:
     url: grpcs://localhost:7030
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.orderer.example.com
   orderer1.group1.orderer.example.com:
     url: grpcs://localhost:7031
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer1.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer1.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer1.group1.orderer.example.com
   orderer0.group1.org1.example.com:
     url: grpcs://localhost:7050
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org1.example.com/orderers/orderer0.group1.org1.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/orderer0.group1.org1.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.org1.example.com
   orderer1.group1.org1.example.com:
     url: grpcs://localhost:7051
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org1.example.com/orderers/orderer1.group1.org1.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/orderer1.group1.org1.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer1.group1.org1.example.com
   orderer0.group1.org2.example.com:
     url: grpcs://localhost:7070
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org2.example.com/orderers/orderer0.group1.org2.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org2.example.com/peers/orderer0.group1.org2.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.org2.example.com
   orderer1.group1.org2.example.com:
     url: grpcs://localhost:7071
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org2.example.com/orderers/orderer1.group1.org2.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org2.example.com/peers/orderer1.group1.org2.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer1.group1.org2.example.com
   orderer0.group1.org3.example.com:
     url: grpcs://localhost:7090
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org3.example.com/orderers/orderer0.group1.org3.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org3.example.com/peers/orderer0.group1.org3.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.org3.example.com
   orderer1.group1.org3.example.com:
     url: grpcs://localhost:7091
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org3.example.com/orderers/orderer1.group1.org3.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org3.example.com/peers/orderer1.group1.org3.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer1.group1.org3.example.com
 "
@@ -869,7 +869,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer0.group1.orderer.example.com": {
       "url": "grpcs://localhost:7030",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.orderer.example.com"
@@ -878,7 +878,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer1.group1.orderer.example.com": {
       "url": "grpcs://localhost:7031",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer1.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer1.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer1.group1.orderer.example.com"
@@ -887,7 +887,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer0.group1.org1.example.com": {
       "url": "grpcs://localhost:7050",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org1.example.com/orderers/orderer0.group1.org1.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/orderer0.group1.org1.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.org1.example.com"
@@ -896,7 +896,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer1.group1.org1.example.com": {
       "url": "grpcs://localhost:7051",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org1.example.com/orderers/orderer1.group1.org1.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/orderer1.group1.org1.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer1.group1.org1.example.com"
@@ -905,7 +905,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer0.group1.org2.example.com": {
       "url": "grpcs://localhost:7070",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org2.example.com/orderers/orderer0.group1.org2.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org2.example.com/peers/orderer0.group1.org2.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.org2.example.com"
@@ -914,7 +914,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer1.group1.org2.example.com": {
       "url": "grpcs://localhost:7071",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org2.example.com/orderers/orderer1.group1.org2.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org2.example.com/peers/orderer1.group1.org2.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer1.group1.org2.example.com"
@@ -923,7 +923,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer0.group1.org3.example.com": {
       "url": "grpcs://localhost:7090",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org3.example.com/orderers/orderer0.group1.org3.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org3.example.com/peers/orderer0.group1.org3.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.org3.example.com"
@@ -932,7 +932,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer1.group1.org3.example.com": {
       "url": "grpcs://localhost:7091",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org3.example.com/orderers/orderer1.group1.org3.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org3.example.com/peers/orderer1.group1.org3.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer1.group1.org3.example.com"
@@ -1026,56 +1026,56 @@ orderers:
     url: grpcs://localhost:7030
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.orderer.example.com
   orderer1.group1.orderer.example.com:
     url: grpcs://localhost:7031
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer1.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer1.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer1.group1.orderer.example.com
   orderer0.group1.org1.example.com:
     url: grpcs://localhost:7050
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org1.example.com/orderers/orderer0.group1.org1.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/orderer0.group1.org1.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.org1.example.com
   orderer1.group1.org1.example.com:
     url: grpcs://localhost:7051
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org1.example.com/orderers/orderer1.group1.org1.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/orderer1.group1.org1.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer1.group1.org1.example.com
   orderer0.group1.org2.example.com:
     url: grpcs://localhost:7070
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org2.example.com/orderers/orderer0.group1.org2.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org2.example.com/peers/orderer0.group1.org2.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.org2.example.com
   orderer1.group1.org2.example.com:
     url: grpcs://localhost:7071
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org2.example.com/orderers/orderer1.group1.org2.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org2.example.com/peers/orderer1.group1.org2.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer1.group1.org2.example.com
   orderer0.group1.org3.example.com:
     url: grpcs://localhost:7090
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org3.example.com/orderers/orderer0.group1.org3.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org3.example.com/peers/orderer0.group1.org3.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.org3.example.com
   orderer1.group1.org3.example.com:
     url: grpcs://localhost:7091
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org3.example.com/orderers/orderer1.group1.org3.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org3.example.com/peers/orderer1.group1.org3.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer1.group1.org3.example.com
 channels:
@@ -1182,7 +1182,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer0.group1.orderer.example.com": {
       "url": "grpcs://localhost:7030",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.orderer.example.com"
@@ -1191,7 +1191,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer1.group1.orderer.example.com": {
       "url": "grpcs://localhost:7031",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer1.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer1.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer1.group1.orderer.example.com"
@@ -1200,7 +1200,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer0.group1.org1.example.com": {
       "url": "grpcs://localhost:7050",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org1.example.com/orderers/orderer0.group1.org1.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/orderer0.group1.org1.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.org1.example.com"
@@ -1209,7 +1209,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer1.group1.org1.example.com": {
       "url": "grpcs://localhost:7051",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org1.example.com/orderers/orderer1.group1.org1.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/orderer1.group1.org1.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer1.group1.org1.example.com"
@@ -1218,7 +1218,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer0.group1.org2.example.com": {
       "url": "grpcs://localhost:7070",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org2.example.com/orderers/orderer0.group1.org2.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org2.example.com/peers/orderer0.group1.org2.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.org2.example.com"
@@ -1227,7 +1227,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer1.group1.org2.example.com": {
       "url": "grpcs://localhost:7071",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org2.example.com/orderers/orderer1.group1.org2.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org2.example.com/peers/orderer1.group1.org2.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer1.group1.org2.example.com"
@@ -1236,7 +1236,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer0.group1.org3.example.com": {
       "url": "grpcs://localhost:7090",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org3.example.com/orderers/orderer0.group1.org3.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org3.example.com/peers/orderer0.group1.org3.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.org3.example.com"
@@ -1245,7 +1245,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer1.group1.org3.example.com": {
       "url": "grpcs://localhost:7091",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org3.example.com/orderers/orderer1.group1.org3.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org3.example.com/peers/orderer1.group1.org3.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer1.group1.org3.example.com"
@@ -1339,56 +1339,56 @@ orderers:
     url: grpcs://localhost:7030
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.orderer.example.com
   orderer1.group1.orderer.example.com:
     url: grpcs://localhost:7031
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer1.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer1.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer1.group1.orderer.example.com
   orderer0.group1.org1.example.com:
     url: grpcs://localhost:7050
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org1.example.com/orderers/orderer0.group1.org1.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/orderer0.group1.org1.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.org1.example.com
   orderer1.group1.org1.example.com:
     url: grpcs://localhost:7051
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org1.example.com/orderers/orderer1.group1.org1.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/orderer1.group1.org1.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer1.group1.org1.example.com
   orderer0.group1.org2.example.com:
     url: grpcs://localhost:7070
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org2.example.com/orderers/orderer0.group1.org2.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org2.example.com/peers/orderer0.group1.org2.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.org2.example.com
   orderer1.group1.org2.example.com:
     url: grpcs://localhost:7071
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org2.example.com/orderers/orderer1.group1.org2.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org2.example.com/peers/orderer1.group1.org2.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer1.group1.org2.example.com
   orderer0.group1.org3.example.com:
     url: grpcs://localhost:7090
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org3.example.com/orderers/orderer0.group1.org3.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org3.example.com/peers/orderer0.group1.org3.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.org3.example.com
   orderer1.group1.org3.example.com:
     url: grpcs://localhost:7091
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org3.example.com/orderers/orderer1.group1.org3.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org3.example.com/peers/orderer1.group1.org3.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer1.group1.org3.example.com
 channels:
@@ -1495,7 +1495,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer0.group1.orderer.example.com": {
       "url": "grpcs://localhost:7030",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.orderer.example.com"
@@ -1504,7 +1504,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer1.group1.orderer.example.com": {
       "url": "grpcs://localhost:7031",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer1.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer1.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer1.group1.orderer.example.com"
@@ -1513,7 +1513,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer0.group1.org1.example.com": {
       "url": "grpcs://localhost:7050",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org1.example.com/orderers/orderer0.group1.org1.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/orderer0.group1.org1.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.org1.example.com"
@@ -1522,7 +1522,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer1.group1.org1.example.com": {
       "url": "grpcs://localhost:7051",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org1.example.com/orderers/orderer1.group1.org1.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/orderer1.group1.org1.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer1.group1.org1.example.com"
@@ -1531,7 +1531,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer0.group1.org2.example.com": {
       "url": "grpcs://localhost:7070",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org2.example.com/orderers/orderer0.group1.org2.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org2.example.com/peers/orderer0.group1.org2.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.org2.example.com"
@@ -1540,7 +1540,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer1.group1.org2.example.com": {
       "url": "grpcs://localhost:7071",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org2.example.com/orderers/orderer1.group1.org2.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org2.example.com/peers/orderer1.group1.org2.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer1.group1.org2.example.com"
@@ -1549,7 +1549,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer0.group1.org3.example.com": {
       "url": "grpcs://localhost:7090",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org3.example.com/orderers/orderer0.group1.org3.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org3.example.com/peers/orderer0.group1.org3.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.org3.example.com"
@@ -1558,7 +1558,7 @@ exports[`samples/fablo-config-hlf2-3orgs-1chaincode-raft-explorer.json should cr
     "orderer1.group1.org3.example.com": {
       "url": "grpcs://localhost:7091",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org3.example.com/orderers/orderer1.group1.org3.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org3.example.com/peers/orderer1.group1.org3.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer1.group1.org3.example.com"
@@ -1644,56 +1644,56 @@ orderers:
     url: grpcs://localhost:7030
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.orderer.example.com
   orderer1.group1.orderer.example.com:
     url: grpcs://localhost:7031
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer1.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer1.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer1.group1.orderer.example.com
   orderer0.group1.org1.example.com:
     url: grpcs://localhost:7050
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org1.example.com/orderers/orderer0.group1.org1.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/orderer0.group1.org1.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.org1.example.com
   orderer1.group1.org1.example.com:
     url: grpcs://localhost:7051
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org1.example.com/orderers/orderer1.group1.org1.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org1.example.com/peers/orderer1.group1.org1.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer1.group1.org1.example.com
   orderer0.group1.org2.example.com:
     url: grpcs://localhost:7070
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org2.example.com/orderers/orderer0.group1.org2.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org2.example.com/peers/orderer0.group1.org2.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.org2.example.com
   orderer1.group1.org2.example.com:
     url: grpcs://localhost:7071
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org2.example.com/orderers/orderer1.group1.org2.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org2.example.com/peers/orderer1.group1.org2.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer1.group1.org2.example.com
   orderer0.group1.org3.example.com:
     url: grpcs://localhost:7090
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org3.example.com/orderers/orderer0.group1.org3.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org3.example.com/peers/orderer0.group1.org3.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.org3.example.com
   orderer1.group1.org3.example.com:
     url: grpcs://localhost:7091
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/org3.example.com/orderers/orderer1.group1.org3.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/org3.example.com/peers/orderer1.group1.org3.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer1.group1.org3.example.com
 "

--- a/e2e/__snapshots__/fablo-config-hlf3-1orgs-2chaincodes.json.test.ts.snap
+++ b/e2e/__snapshots__/fablo-config-hlf3-1orgs-2chaincodes.json.test.ts.snap
@@ -328,7 +328,7 @@ exports[`samples/fablo-config-hlf3-1orgs-2chaincodes.json should create proper e
     "orderer0.group1.orderer.example.com": {
       "url": "grpcs://localhost:7030",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.orderer.example.com"
@@ -337,7 +337,7 @@ exports[`samples/fablo-config-hlf3-1orgs-2chaincodes.json should create proper e
     "orderer1.group1.orderer.example.com": {
       "url": "grpcs://localhost:7031",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer1.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer1.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer1.group1.orderer.example.com"
@@ -346,7 +346,7 @@ exports[`samples/fablo-config-hlf3-1orgs-2chaincodes.json should create proper e
     "orderer2.group1.orderer.example.com": {
       "url": "grpcs://localhost:7032",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer2.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer2.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer2.group1.orderer.example.com"
@@ -355,7 +355,7 @@ exports[`samples/fablo-config-hlf3-1orgs-2chaincodes.json should create proper e
     "orderer3.group1.orderer.example.com": {
       "url": "grpcs://localhost:7033",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer3.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer3.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer3.group1.orderer.example.com"
@@ -409,28 +409,28 @@ orderers:
     url: grpcs://localhost:7030
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.orderer.example.com
   orderer1.group1.orderer.example.com:
     url: grpcs://localhost:7031
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer1.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer1.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer1.group1.orderer.example.com
   orderer2.group1.orderer.example.com:
     url: grpcs://localhost:7032
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer2.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer2.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer2.group1.orderer.example.com
   orderer3.group1.orderer.example.com:
     url: grpcs://localhost:7033
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer3.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer3.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer3.group1.orderer.example.com
 "
@@ -492,7 +492,7 @@ exports[`samples/fablo-config-hlf3-1orgs-2chaincodes.json should create proper e
     "orderer0.group1.orderer.example.com": {
       "url": "grpcs://localhost:7030",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.orderer.example.com"
@@ -501,7 +501,7 @@ exports[`samples/fablo-config-hlf3-1orgs-2chaincodes.json should create proper e
     "orderer1.group1.orderer.example.com": {
       "url": "grpcs://localhost:7031",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer1.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer1.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer1.group1.orderer.example.com"
@@ -510,7 +510,7 @@ exports[`samples/fablo-config-hlf3-1orgs-2chaincodes.json should create proper e
     "orderer2.group1.orderer.example.com": {
       "url": "grpcs://localhost:7032",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer2.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer2.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer2.group1.orderer.example.com"
@@ -519,7 +519,7 @@ exports[`samples/fablo-config-hlf3-1orgs-2chaincodes.json should create proper e
     "orderer3.group1.orderer.example.com": {
       "url": "grpcs://localhost:7033",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer3.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer3.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer3.group1.orderer.example.com"
@@ -578,28 +578,28 @@ orderers:
     url: grpcs://localhost:7030
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.orderer.example.com
   orderer1.group1.orderer.example.com:
     url: grpcs://localhost:7031
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer1.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer1.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer1.group1.orderer.example.com
   orderer2.group1.orderer.example.com:
     url: grpcs://localhost:7032
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer2.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer2.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer2.group1.orderer.example.com
   orderer3.group1.orderer.example.com:
     url: grpcs://localhost:7033
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer3.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer3.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer3.group1.orderer.example.com
 channels:

--- a/e2e/__snapshots__/fablo-config-hlf3-2orgs-1chaincode-raft-ccaas.test.ts.snap
+++ b/e2e/__snapshots__/fablo-config-hlf3-2orgs-1chaincode-raft-ccaas.test.ts.snap
@@ -349,7 +349,7 @@ exports[`samples/fablo-config-hlf3-2orgs-1chaincode-raft-ccaas.json should creat
     "orderer0.group1.orderer.example.com": {
       "url": "grpcs://localhost:7030",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.orderer.example.com"
@@ -403,7 +403,7 @@ orderers:
     url: grpcs://localhost:7030
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.orderer.example.com
 "
@@ -465,7 +465,7 @@ exports[`samples/fablo-config-hlf3-2orgs-1chaincode-raft-ccaas.json should creat
     "orderer0.group1.orderer.example.com": {
       "url": "grpcs://localhost:7030",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.orderer.example.com"
@@ -524,7 +524,7 @@ orderers:
     url: grpcs://localhost:7030
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.orderer.example.com
 channels:
@@ -589,7 +589,7 @@ exports[`samples/fablo-config-hlf3-2orgs-1chaincode-raft-ccaas.json should creat
     "orderer0.group1.orderer.example.com": {
       "url": "grpcs://localhost:7030",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.orderer.example.com"
@@ -648,7 +648,7 @@ orderers:
     url: grpcs://localhost:7030
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.orderer.example.com
 channels:

--- a/e2e/__snapshots__/fablo-config-hlf3-bft-1orgs-1chaincode.json.test.ts.snap
+++ b/e2e/__snapshots__/fablo-config-hlf3-bft-1orgs-1chaincode.json.test.ts.snap
@@ -348,7 +348,7 @@ exports[`samples/fablo-config-hlf3-bft-1orgs-1chaincode.json should create prope
     "orderer0.group1.orderer.example.com": {
       "url": "grpcs://localhost:7030",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.orderer.example.com"
@@ -357,7 +357,7 @@ exports[`samples/fablo-config-hlf3-bft-1orgs-1chaincode.json should create prope
     "orderer1.group1.orderer.example.com": {
       "url": "grpcs://localhost:7031",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer1.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer1.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer1.group1.orderer.example.com"
@@ -366,7 +366,7 @@ exports[`samples/fablo-config-hlf3-bft-1orgs-1chaincode.json should create prope
     "orderer2.group1.orderer.example.com": {
       "url": "grpcs://localhost:7032",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer2.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer2.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer2.group1.orderer.example.com"
@@ -375,7 +375,7 @@ exports[`samples/fablo-config-hlf3-bft-1orgs-1chaincode.json should create prope
     "orderer3.group1.orderer.example.com": {
       "url": "grpcs://localhost:7033",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer3.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer3.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer3.group1.orderer.example.com"
@@ -429,28 +429,28 @@ orderers:
     url: grpcs://localhost:7030
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.orderer.example.com
   orderer1.group1.orderer.example.com:
     url: grpcs://localhost:7031
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer1.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer1.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer1.group1.orderer.example.com
   orderer2.group1.orderer.example.com:
     url: grpcs://localhost:7032
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer2.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer2.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer2.group1.orderer.example.com
   orderer3.group1.orderer.example.com:
     url: grpcs://localhost:7033
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer3.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer3.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer3.group1.orderer.example.com
 "
@@ -512,7 +512,7 @@ exports[`samples/fablo-config-hlf3-bft-1orgs-1chaincode.json should create prope
     "orderer0.group1.orderer.example.com": {
       "url": "grpcs://localhost:7030",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer0.group1.orderer.example.com"
@@ -521,7 +521,7 @@ exports[`samples/fablo-config-hlf3-bft-1orgs-1chaincode.json should create prope
     "orderer1.group1.orderer.example.com": {
       "url": "grpcs://localhost:7031",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer1.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer1.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer1.group1.orderer.example.com"
@@ -530,7 +530,7 @@ exports[`samples/fablo-config-hlf3-bft-1orgs-1chaincode.json should create prope
     "orderer2.group1.orderer.example.com": {
       "url": "grpcs://localhost:7032",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer2.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer2.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer2.group1.orderer.example.com"
@@ -539,7 +539,7 @@ exports[`samples/fablo-config-hlf3-bft-1orgs-1chaincode.json should create prope
     "orderer3.group1.orderer.example.com": {
       "url": "grpcs://localhost:7033",
       "tlsCACerts": {
-        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer3.group1.orderer.example.com/tls/ca.crt"
+        "path": "<absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer3.group1.orderer.example.com/tls/ca.crt"
       },
       "grpcOptions": {
         "ssl-target-name-override": "orderer3.group1.orderer.example.com"
@@ -598,28 +598,28 @@ orderers:
     url: grpcs://localhost:7030
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer0.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer0.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer0.group1.orderer.example.com
   orderer1.group1.orderer.example.com:
     url: grpcs://localhost:7031
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer1.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer1.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer1.group1.orderer.example.com
   orderer2.group1.orderer.example.com:
     url: grpcs://localhost:7032
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer2.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer2.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer2.group1.orderer.example.com
   orderer3.group1.orderer.example.com:
     url: grpcs://localhost:7033
     tlsCACerts:
       path: >-
-        <absolute path>/samples/fablo-target/fabric-config/crypto-config/ordererOrganizations/orderer.example.com/orderers/orderer3.group1.orderer.example.com/tls/ca.crt
+        <absolute path>/samples/fablo-target/fabric-config/crypto-config/peerOrganizations/orderer.example.com/peers/orderer3.group1.orderer.example.com/tls/ca.crt
     grpcOptions:
       ssl-target-name-override: orderer3.group1.orderer.example.com
 channels:

--- a/src/types/ConnectionProfile.ts
+++ b/src/types/ConnectionProfile.ts
@@ -189,7 +189,7 @@ function createOrderers(isTls: boolean, rootPath: string, ordererGroups: Orderer
         orderers[orderer.address] = {
           url: `grpcs://localhost:${orderer.port}`,
           tlsCACerts: {
-            path: `${rootPath}/ordererOrganizations/${orderer.domain}/orderers/${orderer.address}/tls/ca.crt`,
+            path: `${rootPath}/peerOrganizations/${orderer.domain}/peers/${orderer.address}/tls/ca.crt`,
           },
           grpcOptions: {
             "ssl-target-name-override": orderer.address,


### PR DESCRIPTION
### What

Fixes the orderer TLS certificate path in `src/types/ConnectionProfile.ts` line 192.

Two errors in the same path string:
- `ordererOrganizations` → `peerOrganizations` (orderers are defined under `PeerOrgs` in crypto-config)
- `orderers` → `peers` (cryptogen generates them as peers)

```typescript
// Before:
path: `${rootPath}/ordererOrganizations/${orderer.domain}/orderers/${orderer.address}/tls/ca.crt`,
// After:
path: `${rootPath}/peerOrganizations/${orderer.domain}/peers/${orderer.address}/tls/ca.crt`,
```
Fixes #729 