### PR TITLE
docs: add WSL2 troubleshooting guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ Note: If you install Fablo as a local script, you call it as `./fablo <command>`
 If you install it globally, you call `fablo <command>`.
 For the simplicity we will refer to it as `fablo`.
 
+###Troubleshooting for WSL2 & Ubuntu Users 
+If you are running Fablo on **Windows Subsystem for Linux (WSL2)**, you may encounter environment-specific issues. Here are the recommended fixes:
+
+* **Docker V2 Syntax:** Ensure you use `docker compose` (with a space) instead of `docker-compose`.
+* **Socket Permissions: **If you get a "permission denied" error, run:
+   `sudo chmod 666 /var/run/docker.sock`
+* **command Stability:** In WSL2, use the full flag `--detach` instead of `-d` when intializing the network to ensure the containers start correctly.
+* **WSL2 Integration:** Confirm that "WSL2 Integration" is enabled in Docker Desktop settings for your specific Ubuntu distribution. 
 
 ## Basic usage
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ If you are running Fablo on **Windows Subsystem for Linux (WSL2)**, you may enco
 * **Docker V2 Syntax:** Ensure you use `docker compose` (with a space) instead of `docker-compose`.
 * **Socket Permissions: **If you get a "permission denied" error, run:
    `sudo chmod 666 /var/run/docker.sock`
-* **command Stability:** In WSL2, use the full flag `--detach` instead of `-d` when intializing the network to ensure the containers start correctly.
+
 * **WSL2 Integration:** Confirm that "WSL2 Integration" is enabled in Docker Desktop settings for your specific Ubuntu distribution. 
 
 ## Basic usage


### PR DESCRIPTION
Added specific steps for socket permissions and docker compose syntax for WSL2 users.