### PR TITLE
docs: clarify v2/v3 suffix semantics in setup-docker vs setup-k8s

### DIFF
--- a/src/setup-docker/index.ts
+++ b/src/setup-docker/index.ts
@@ -84,6 +84,10 @@ export default class SetupDocker extends Command {
 
     // ======= scripts ==================================================================
     await this._copyCommandsGeneratedScript(configExtended);
+    // NOTE: "v2"/"v3" suffix in _copyUtilityScripts refers to HLF version (isV3 flag).
+    // This is different from setup-k8s where the same suffix distinguishes
+    // old Fabric 1.4-style install flow vs newer — not HLF version.
+    // See src/setup-k8s/index.ts _copyUtilityScripts for comparison.
     await this._copyUtilityScripts(configExtended.global.capabilities);
 
     // ======= hooks ====================================================================

--- a/src/setup-k8s/index.ts
+++ b/src/setup-k8s/index.ts
@@ -55,6 +55,9 @@ export default class SetupK8s extends Command {
 
     // ======= scripts ==================================================================
     await this._copyCommandsGeneratedScript(configExtended);
+    // NOTE: "v2"/"v1" suffix here refers to old Fabric 1.4-style install flow vs newer — not HLF version.
+    // This is different from setup-docker where the same suffix means HLF version (isV3 flag).
+    // See src/setup-docker/index.ts _copyUtilityScripts for comparison.
     await this._copyUtilityScripts(configExtended.global.capabilities);
 
     // ======= hooks ====================================================================


### PR DESCRIPTION
The `v2`/`v3` suffix in `_copyUtilityScripts` means different things 
depending on which setup file you're in:

- In `setup-docker`, it refers to HLF version via the `isV3` flag
- In `setup-k8s`, it distinguishes old Fabric 1.4-style install flow from newer ones

Same filename pattern, completely different meaning — easy to misread 
when grepping across the codebase.

Added clarifying comments above each `_copyUtilityScripts` call pointing 
to the other file for comparison.

Refs #702