### PR TITLE
fix: correct isV3 ternary in chaincode-functions and add clarifying comments

### DIFF
--- a/src/setup-docker/index.ts
+++ b/src/setup-docker/index.ts
@@ -242,7 +242,11 @@ export default class SetupDocker extends Command {
       }
     }
   }
-
+  // NOTE: "v2"/"v3" suffixes below refer to Hyperledger Fabric major version (HLF2 vs HLF3),
+  // driven by capabilities.isV3.
+  // This is DIFFERENT from setup-k8s where "v2"/"v1.4" refers to the chaincode install
+  // flow style (Fabric 2.x lifecycle vs old 1.4-style). Same filename pattern, different meaning.
+  // See: src/setup-k8s/index.ts _copyUtilityScripts
   async _copyUtilityScripts(capabilities: Capabilities): Promise<void> {
     // Copy fabric-docker.sh
     // const { capabilities } = global;
@@ -279,7 +283,7 @@ export default class SetupDocker extends Command {
     // Copy chaincode-functions script
     const chaincodeFunctionsTemplate = getTemplatePath(
       this.templatesDir,
-      `fabric-docker/scripts/chaincode-functions-${capabilities.isV2 ? "v2" : "v2"}.sh`,
+      `fabric-docker/scripts/chaincode-functions-${capabilities.isV3 ? "v3" : "v2"}.sh`,
     );
     const chaincodeFunctionsDest = getDestinationPath(this.outputDir, "fabric-docker/scripts/chaincode-functions.sh");
     await renderTemplate(chaincodeFunctionsTemplate, chaincodeFunctionsDest, {});

--- a/src/setup-k8s/index.ts
+++ b/src/setup-k8s/index.ts
@@ -106,6 +106,11 @@ export default class SetupK8s extends Command {
     await renderTemplate(templatePath, destPath, config as unknown as Record<string, unknown>);
   }
 
+  // NOTE: "v2"/"v1.4" suffixes below refer to the chaincode install flow style
+  // (Fabric 2.x lifecycle vs old 1.4-style), driven by capabilities.isV2.
+  // This is DIFFERENT from setup-docker where "v2"/"v3" means HLF major version.
+  // Same filename pattern, different meaning — don't assume the suffixes line up.
+  // See: src/setup-docker/index.ts _copyUtilityScripts
   async _copyUtilityScripts(capabilities: Capabilities): Promise<void> {
     // Copy fabric-k8s.sh
     const fabricK8sShTemplate = getTemplatePath(this.templatesDir, "fabric-k8s.sh");


### PR DESCRIPTION
Both branches of the ternary in _copyUtilityScripts() returned 'v2',
so Fabric v3 users silently got the v2 chaincode-functions.sh template.
Fixed to use capabilities.isV3 like the other scripts in the same method.

Added cross-reference comments above _copyUtilityScripts in both
setup-docker and setup-k8s clarifying that the version suffixes mean
different things in each context (HLF version vs install flow style).

Fixes #702