### PR TITLE
fix: add set -o pipefail to fablo.sh to prevent silent pipeline failures

### DIFF
--- a/fablo.sh
+++ b/fablo.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+set -o pipefail
 
 FABLO_VERSION=2.6.0
 FABLO_IMAGE_NAME="ghcr.io/fablo-io/fablo"


### PR DESCRIPTION
Problem:
`fablo.sh` was missing `set -o pipefail`, allowing pipeline errors
to be silently swallowed. With only `set -e`, the exit code of a
pipeline is determined by the last command — if an earlier command
fails, the script continues executing without error.

Fix:
Added `set -o pipefail` after `set -e` on line 2 of `fablo.sh`.

Testing
- `npm run test:unit` ✅ (17/17 passing)

Fixes #744 