### PR TITLE
fix: add git user identity to release-on-tag workflow

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Create next development version PR
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           sh ./bump-version.sh unstable
           NEW_VERSION=$(jq -r '.version' <"$GITHUB_WORKSPACE/package.json")
           BRANCH_NAME="bump-version-to-$NEW_VERSION"


### PR DESCRIPTION
This PR adds the missing git user identity configuration to the release-on-tag workflow. This ensures that the automated commit process can identify the author and prevents the 'identity not set' error.

fixes #715