### PR TITLE
fix: use headPeer.address in anchor peer update instead of hardcoded peer0

### DIFF
--- a/e2e/__snapshots__/fablo-config-hlf2-2orgs-2chaincodes-raft.yaml.test.ts.snap
+++ b/e2e/__snapshots__/fablo-config-hlf2-2orgs-2chaincodes-raft.yaml.test.ts.snap
@@ -4314,8 +4314,8 @@ notifyOrgsAboutChannels() {
   printHeadline "Notyfing orgs about channels" "U1F4E2"
   notifyOrgAboutNewChannelTls "my-channel1" "Org1MSP" "cli.org1.example.com" "peer0.org1.example.com" "orderer0.group1.orderer1.com:7030" "crypto-orderer/tlsca.orderer1.com-cert.pem"
   notifyOrgAboutNewChannelTls "my-channel1" "Org2MSP" "cli.org2.example.com" "peer0.org2.example.com" "orderer0.group1.orderer1.com:7030" "crypto-orderer/tlsca.orderer1.com-cert.pem"
-  notifyOrgAboutNewChannelTls "my-channel2" "Org1MSP" "cli.org1.example.com" "peer0.org1.example.com" "orderer0.group1.orderer1.com:7030" "crypto-orderer/tlsca.orderer1.com-cert.pem"
-  notifyOrgAboutNewChannelTls "my-channel2" "Org2MSP" "cli.org2.example.com" "peer0.org2.example.com" "orderer0.group1.orderer1.com:7030" "crypto-orderer/tlsca.orderer1.com-cert.pem"
+  notifyOrgAboutNewChannelTls "my-channel2" "Org1MSP" "cli.org1.example.com" "peer1.org1.example.com" "orderer0.group1.orderer1.com:7030" "crypto-orderer/tlsca.orderer1.com-cert.pem"
+  notifyOrgAboutNewChannelTls "my-channel2" "Org2MSP" "cli.org2.example.com" "peer1.org2.example.com" "orderer0.group1.orderer1.com:7030" "crypto-orderer/tlsca.orderer1.com-cert.pem"
   notifyOrgAboutNewChannelTls "my-channel3" "Org1MSP" "cli.org1.example.com" "peer0.org1.example.com" "orderer0.group2.orderer2.com:7050" "crypto-orderer/tlsca.orderer2.com-cert.pem"
   notifyOrgAboutNewChannelTls "my-channel3" "Org2MSP" "cli.org2.example.com" "peer0.org2.example.com" "orderer0.group2.orderer2.com:7050" "crypto-orderer/tlsca.orderer2.com-cert.pem"
 

--- a/src/setup-docker/templates/fabric-docker/commands-generated.sh
+++ b/src/setup-docker/templates/fabric-docker/commands-generated.sh
@@ -216,14 +216,14 @@ notifyOrgsAboutChannels() {
          "<%= channel.name %>" <% -%>
          "<%= org.mspName %>" <% -%>
          "<%= org.cli.address %>" <% -%>
-         "peer0.<%= org.domain %>" <% -%>
+         "<%= org.headPeer.address %>" <% -%>
          "<%= channel.ordererHead.fullAddress %>"
       <% } else { -%>
         notifyOrgAboutNewChannelTls <% -%>
          "<%= channel.name %>" <% -%>
          "<%= org.mspName %>" <% -%>
          "<%= org.cli.address %>" <% -%>
-         "peer0.<%= org.domain %>" <% -%>
+         "<%= org.headPeer.address %>" <% -%>
          "<%= channel.ordererHead.fullAddress %>" <% -%>
          "crypto-orderer/tlsca.<%= channel.ordererHead.domain %>-cert.pem"
       <% } -%>


### PR DESCRIPTION
## Summary
`notifyOrgAboutNewChannel` and `notifyOrgAboutNewChannelTls` in `commands-generated.sh` were hardcoding `peer0.<org.domain>` as the peer address instead of respecting the `peer.prefix` config field. If you set a custom prefix like `"prefix": "node"`, everything else in the generated file picks it up and uses `node0.org1.example.com`, but the anchor peer update was still pointing at `peer0.org1.example.com` which doesn't exist as a container. Docker DNS silently fails with no obvious indication that the prefix config is being ignored.

## Fix
Switched to `org.headPeer.address` which already handles the prefix correctly. `headPeer` is just `peers[0]` from the prefix-aware peer list built in `extendOrgsConfig.ts:258`, and the same pattern is already used in `chaincode-install-v2.sh` and `chaincode-dev-v2.sh`. All 17 unit tests pass.

Fixes #751 