### PR TITLE
Fix: remove duplicate Fabric version validation (_verifyFabricVersion is dead code)

### DIFF
--- a/src/commands/validate/index.ts
+++ b/src/commands/validate/index.ts
@@ -147,7 +147,6 @@ export default class Validate extends Command {
     this._validateExplorerWithFabricVersion(networkConfig.global, networkConfig.orgs);
     this._validateDevMode(networkConfig.global);
     this._validateFabloRestAndDevMode(networkConfig.global, networkConfig.orgs);
-    this._verifyFabricVersion(networkConfig.global);
   }
 
   private _validateFabricVersion(global: GlobalJson) {
@@ -556,13 +555,6 @@ export default class Validate extends Command {
           };
           this.emit(validationErrorType.ERROR, objectToEmit);
         });
-    }
-  }
-
-  _verifyFabricVersion(global: GlobalJson) {
-    if (!version(global.fabricVersion).isGreaterOrEqual("2.0.0")) {
-      const message = `Fablo supports Fabric in version 2.0.0 and higher`;
-      this.emit(validationErrorType.ERROR, { category: validationCategories.GENERAL, message });
     }
   }
 


### PR DESCRIPTION
## Summary

Removes the redundant `_verifyFabricVersion()` method and its call in `src/commands/validate/index.ts`.

### Problem

Two separate methods check the **exact same condition** — whether `fabricVersion >= 2.0.0`:

1. **`_validateFabricVersion()`** (line 153) — emits a `CRITICAL` error → calls `process.exit(1)` immediately
2. **`_verifyFabricVersion()`** (line 562) — emits a regular `ERROR` → just adds to error list

Since `_validateFabricVersion` is called first (line 118) and exits the process on failure, `_verifyFabricVersion` (called at line 150) is **unreachable dead code** when the version check fails.

### Fix

Remove the redundant `_verifyFabricVersion` method (lines 562-567) and its call (line 150). The existing `_validateFabricVersion` already handles this correctly with a CRITICAL exit.

### Testing

- ✅ `npm run test:unit` — 34/34 tests pass
- ✅ `npm run lint` — 0 errors, 23 warnings (same as baseline minus 1 removed warning from dead code)
- ✅ `npm run build` — compiles successfully

Fixes #763