### PR TITLE
fix: guard Consortium field for Fabric V3 in configtx.yaml

### DIFF
--- a/e2e/__snapshots__/fablo-config-hlf2-1org-2chaincode-raft-ccaas.json.test.ts.snap
+++ b/e2e/__snapshots__/fablo-config-hlf2-1org-2chaincode-raft-ccaas.json.test.ts.snap
@@ -257,7 +257,6 @@ Profiles:
             <<: *Group1Defaults
             Organizations:
                 - *Orderer
-        Consortium: SampleConsortium
         Application:
             <<: *ApplicationDefaults
             Organizations:
@@ -269,7 +268,6 @@ Profiles:
             <<: *Group1Defaults
             Organizations:
                 - *Orderer
-        Consortium: SampleConsortium
         Application:
             <<: *ApplicationDefaults
             Organizations:

--- a/e2e/__snapshots__/fablo-config-hlf3-1orgs-2chaincodes.json.test.ts.snap
+++ b/e2e/__snapshots__/fablo-config-hlf3-1orgs-2chaincodes.json.test.ts.snap
@@ -264,7 +264,6 @@ Profiles:
             <<: *Group1Defaults
             Organizations:
                 - *Orderer
-        Consortium: SampleConsortium
         Application:
             <<: *ApplicationDefaults
             Organizations:

--- a/e2e/__snapshots__/fablo-config-hlf3-2orgs-1chaincode-raft-ccaas.test.ts.snap
+++ b/e2e/__snapshots__/fablo-config-hlf3-2orgs-1chaincode-raft-ccaas.test.ts.snap
@@ -284,7 +284,6 @@ Profiles:
             <<: *Group1Defaults
             Organizations:
                 - *Orderer
-        Consortium: SampleConsortium
         Application:
             <<: *ApplicationDefaults
             Organizations:

--- a/e2e/__snapshots__/fablo-config-hlf3-bft-1orgs-1chaincode.json.test.ts.snap
+++ b/e2e/__snapshots__/fablo-config-hlf3-bft-1orgs-1chaincode.json.test.ts.snap
@@ -284,7 +284,6 @@ Profiles:
             <<: *Group1Defaults
             Organizations:
                 - *Orderer
-        Consortium: SampleConsortium
         Application:
             <<: *ApplicationDefaults
             Organizations:

--- a/src/setup-docker/templates/fabric-config/configtx.yaml
+++ b/src/setup-docker/templates/fabric-config/configtx.yaml
@@ -168,7 +168,9 @@ Profiles:
             Capabilities:
                 <<: *ApplicationCapabilities
         <%_ } _%>
-        Consortium: SampleConsortium
+        <%_ if (!global.capabilities.isV3) { _%>
+            Consortium: SampleConsortium
+        <%_ } _%>
         <%_ if (!global.capabilities.isV3) { _%>
         Consortiums:
             SampleConsortium:

--- a/src/setup-docker/templates/fabric-config/configtx.yaml
+++ b/src/setup-docker/templates/fabric-config/configtx.yaml
@@ -169,7 +169,7 @@ Profiles:
                 <<: *ApplicationCapabilities
         <%_ } _%>
         <%_ if (!global.capabilities.isV3) { _%>
-            Consortium: SampleConsortium
+        Consortium: SampleConsortium
         <%_ } _%>
         <%_ if (!global.capabilities.isV3) { _%>
         Consortiums:


### PR DESCRIPTION
Commit adc995e correctly guarded the Consortiums block with !isV3, but the scalar Consortium: SampleConsortium field immediately above it was left unguarded and renders for all Fabric versions including V3:

Fixes #757