### PR TITLE
  Removes the unused hyperledgerExplorerVersion: "1.1.8" setting from src/setup-k8s/index.ts.

### DIFF
--- a/src/setup-k8s/index.ts
+++ b/src/setup-k8s/index.ts
@@ -90,7 +90,6 @@ export default class SetupK8s extends Command {
       fabloVersion: config.fabloVersion,
       fabloBuild: getBuildInfo(),
       fabloRestVersion: "0.2.0",
-      hyperledgerExplorerVersion: "1.1.8",
       fabricCouchDbVersion: "0.4.18",
       couchDbVersion: "3.1",
       fabricCaPostgresVersion: "14",


### PR DESCRIPTION

  I ran the generator: the produced K8s .env doesn't contain the explorer version at all (whereas the Docker output does, proving the test would catch it if it were used), and after removing the line the K8s
  snapshot test passes with byte-identical output. Since this value's only possible effect is to be rendered into a generated file, and it reaches none, removing it is safe and changes nothing.
