### PR TITLE
 fix: correct init/initRequired validation warning messages

### DIFF
--- a/src/commands/validate/index.ts
+++ b/src/commands/validate/index.ts
@@ -359,14 +359,14 @@ export default class Validate extends Command {
       if (!!chaincode.init && capabilities.isV2) {
         const objectToEmit = {
           category: validationCategories.CHAINCODE,
-          message: `Chaincode 'init' parameters are only supported in Fabric prior to 2.0 (${chaincode.name})`,
+          message: `Chaincode 'init' parameter is not used in Fabric 2.x and will be ignored; use 'initRequired' instead (${chaincode.name})`,
         };
         this.emit(validationErrorType.WARN, objectToEmit);
       }
       if (!!chaincode.initRequired && !capabilities.isV2) {
         const objectToEmit = {
           category: validationCategories.CHAINCODE,
-          message: `Chaincode 'initRequired' parameter is supported only in Fabric prior to 2.0 and will be ignored (${chaincode.name})`,
+          message: `Chaincode 'initRequired' parameter is only used in Fabric 2.x and will be ignored; use 'init' instead (${chaincode.name})`,
         };
         this.emit(validationErrorType.WARN, objectToEmit);
       }


### PR DESCRIPTION


Fixes #718


## Problem
In `src/commands/validate/index.ts`, the validation warnings for the chaincode
`init` and `initRequired` options printed inverted, misleading text. The
conditions correctly detected the mismatched configurations, but the messages
described the wrong Fabric version supporting each parameter — `initRequired`
was even described as a pre-2.0 feature, which is incorrect (it's a v2+
chaincode lifecycle feature).
