### PR TITLE
fix: remove unused hyperledgerExplorerVersion from k8s setup

### DIFF
--- a/src/setup-k8s/index.ts
+++ b/src/setup-k8s/index.ts
@@ -90,7 +90,6 @@ export default class SetupK8s extends Command {
       fabloVersion: config.fabloVersion,
       fabloBuild: getBuildInfo(),
       fabloRestVersion: "0.2.0",
-      hyperledgerExplorerVersion: "1.1.8",
       fabricCouchDbVersion: "0.4.18",
       couchDbVersion: "3.1",
       fabricCaPostgresVersion: "14",


### PR DESCRIPTION
fix: remove unused hyperledgerExplorerVersion from k8s setup

Fixes #708

## Problem
`src/setup-k8s/index.ts` hardcoded `hyperledgerExplorerVersion: "1.1.8"`, but
this value is never rendered into any generated K8s file. It only existed as
dead configuration and caused a confusing mismatch with the Docker setup
(issue #708).

## Change
Removed the unused `hyperledgerExplorerVersion` line from the K8s setup.

## Verification
I ran the generator: the produced K8s `.env` doesn't contain the explorer
version at all (whereas the Docker output does, proving the snapshot test would
catch it if it were used). After removing the line, the K8s snapshot test
passes with byte-identical output, confirming the removal changes nothing.