### PR TITLE
fix: wrap file system operations in try/catch in init command

### DIFF
--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -128,12 +128,21 @@ export default class Init extends Command {
 
       const source = path.join(__dirname, '../../../samples/chaincodes/chaincode-kv-node');
       const destination = path.join(process.cwd(), 'chaincodes/chaincode-kv-node');
-      fs.copySync(source, destination);
+      try {
+        fs.copySync(source, destination);
+      } catch (e: any) {
+        this.error(`Failed to copy Node.js chaincode samples to '${destination}': ${e.message}`);
+      }
 
+       try{
       fs.writeFileSync(
         path.join(destination, '.nvmrc'),
         '12'
       );
+      }
+      catch (e: any) {
+        this.error(`Failed to write .nvmrc file to '${destination}': ${e.message}`);
+      }
 
 
       // force build on Node 12, since dev deps (@theledger/fabric-mock-stub) may not work on 16
@@ -173,7 +182,12 @@ export default class Init extends Command {
 
       const src = path.join(__dirname, '../../../samples/gateway');
       const dest = path.join(process.cwd(), 'gateway');
+      try{
       fs.copySync(src, dest);
+      }
+      catch(e:any){
+        this.error(`Failed to copy gateway samples to '${dest}': ${e.message}`);
+      }
       this.log('✔ Gateway generated successfully!');
     }
 
@@ -192,8 +206,12 @@ export default class Init extends Command {
     const rootPath = process.cwd();
     const outputFile = path.join(rootPath, 'fablo-config.json');
     // fs.write(this.destinationPath("fablo-config.json"), JSON.stringify(fabloConfigJson, undefined, 2));
+    try{
     fs.writeFileSync(outputFile, JSON.stringify(fabloConfigJson, null, 2));
-
+    }
+    catch(e:any){
+      this.error(`Failed to write fablo-config.json to '${outputFile}': ${e.message}`);
+    }
     this.log("===========================================================");
     this.log(chalk.bold("Sample config file created! :)"));
     this.log("You can start your network with 'fablo up' command");

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -134,11 +134,11 @@ export default class Init extends Command {
         this.error(`Failed to copy Node.js chaincode samples to '${destination}': ${e.message}`);
       }
 
-       try{
-      fs.writeFileSync(
-        path.join(destination, '.nvmrc'),
-        '12'
-      );
+      try {
+        fs.writeFileSync(
+          path.join(destination, '.nvmrc'),
+          '12'
+        );
       }
       catch (e: any) {
         this.error(`Failed to write .nvmrc file to '${destination}': ${e.message}`);
@@ -182,10 +182,10 @@ export default class Init extends Command {
 
       const src = path.join(__dirname, '../../../samples/gateway');
       const dest = path.join(process.cwd(), 'gateway');
-      try{
-      fs.copySync(src, dest);
+      try {
+        fs.copySync(src, dest);
       }
-      catch(e:any){
+      catch (e: any) {
         this.error(`Failed to copy gateway samples to '${dest}': ${e.message}`);
       }
       this.log('✔ Gateway generated successfully!');
@@ -206,10 +206,10 @@ export default class Init extends Command {
     const rootPath = process.cwd();
     const outputFile = path.join(rootPath, 'fablo-config.json');
     // fs.write(this.destinationPath("fablo-config.json"), JSON.stringify(fabloConfigJson, undefined, 2));
-    try{
-    fs.writeFileSync(outputFile, JSON.stringify(fabloConfigJson, null, 2));
+    try {
+      fs.writeFileSync(outputFile, JSON.stringify(fabloConfigJson, null, 2));
     }
-    catch(e:any){
+    catch (e: any) {
       this.error(`Failed to write fablo-config.json to '${outputFile}': ${e.message}`);
     }
     this.log("===========================================================");


### PR DESCRIPTION
Fixes #740

Wrapped the 4 file system operations in `copySampleConfig` with try/catch blocks to show a clear error message instead of crashing with a raw Node.js exception.

Before:

<img width="654" height="86" alt="image" src="https://github.com/user-attachments/assets/45ddcf0b-d01b-4cef-a21a-e9054e965ff7" />


After adding try/catch

<img width="643" height="138" alt="image" src="https://github.com/user-attachments/assets/c6a71370-7698-4169-9ac7-1fa64d6ca522" />
