### PR TITLE
Feat788 :Add provider-aware validation gates

### DIFF
--- a/src/commands/validate/index.ts
+++ b/src/commands/validate/index.ts
@@ -116,6 +116,15 @@ export default class Validate extends Command {
 
     const configContent = fs.readFileSync(this.fabloConfigPath, "utf-8");
     const networkConfig = parseFabloConfig(configContent);
+    const provider = networkConfig.global.provider ?? "fabric";
+
+    if (provider === "fabric-x") {
+      this._validateJsonSchema(networkConfig);
+      this._validateSupportedFabloVersion(networkConfig.$schema);
+      this._validateFabricXSettings(networkConfig);
+      return;
+    }
+
     this._validateFabricVersion(networkConfig.global);
     networkConfig.chaincodes.forEach((chaincode) => this._validateCcaaTLS(networkConfig.global, chaincode));
     this._validateJsonSchema(networkConfig);
@@ -525,7 +534,58 @@ export default class Validate extends Command {
 
     // TODO engine-specific validation rules
   }
+  _validateFabricXSettings(networkConfig: FabloConfigJson): void {
+    const { global, chaincodes, channels, orgs } = networkConfig;
 
+    if (global.engine === "kubernetes") {
+      this.emit(validationErrorType.ERROR, {
+        category: validationCategories.GENERAL,
+        message: "fabric-x does not support the 'kubernetes' engine .Use 'docker'",
+      });
+    }
+
+    if (!global.tls) {
+      this.emit(validationErrorType.ERROR, {
+        category: validationCategories.GENERAL,
+        message: "fabric-x requires 'global.tls' to be true.",
+      });
+    }
+
+    if (global.peerDevMode) {
+      this.emit(validationErrorType.ERROR, {
+        category: validationCategories.GENERAL,
+        message: "fabric-x requires 'global.peerDevMode' to be false.",
+      });
+    }
+
+    if (global.tools?.explorer === true || orgs.some((o) => o.tools?.explorer === true)) {
+      this.emit(validationErrorType.ERROR, {
+        category: validationCategories.GENERAL,
+        message: "Explorer is not supported for fabric-x.",
+      });
+    }
+
+    if (orgs.some((o) => o.tools?.fabloRest === true)) {
+      this.emit(validationErrorType.ERROR, {
+        category: validationCategories.GENERAL,
+        message: "Fablo REST is not supported for provider fabric-x.",
+      });
+    }
+
+    if (chaincodes.length > 0) {
+      this.emit(validationErrorType.ERROR, {
+        category: validationCategories.CHAINCODE,
+        message: "fabric-x does not support chaincodes in this PoC.",
+      });
+    }
+
+    if (channels.length !== 1) {
+      this.emit(validationErrorType.ERROR, {
+        category: validationCategories.CHANNEL,
+        message: `fabric-x requires exactly one channel found ${channels.length}.`,
+      });
+    }
+  }
   _validateExplorer(global: GlobalJson, orgs: OrgJson[]): void {
     if (global.tools?.explorer === true) {
       orgs

--- a/src/commands/validate/index.ts
+++ b/src/commands/validate/index.ts
@@ -118,17 +118,15 @@ export default class Validate extends Command {
     const networkConfig = parseFabloConfig(configContent);
     const provider = networkConfig.global.provider ?? "fabric";
 
+    this._validateFabricVersion(networkConfig.global);
+    this._validateJsonSchema(networkConfig);
+    this._validateSupportedFabloVersion(networkConfig.$schema);
+
     if (provider === "fabric-x") {
-      this._validateJsonSchema(networkConfig);
-      this._validateSupportedFabloVersion(networkConfig.$schema);
       this._validateFabricXSettings(networkConfig);
       return;
     }
-
-    this._validateFabricVersion(networkConfig.global);
     networkConfig.chaincodes.forEach((chaincode) => this._validateCcaaTLS(networkConfig.global, chaincode));
-    this._validateJsonSchema(networkConfig);
-    this._validateSupportedFabloVersion(networkConfig.$schema);
     this._validateOrgs(networkConfig.orgs);
     this._validateEngineSpecificSettings(networkConfig);
 


### PR DESCRIPTION
fixes #788
this PR includes commits from #787 since #788 depends on it ,will rebase once that merges.

Changes

Adds provider-aware validation to `fablo validate`. When `global.provider` is 
`"fabric-x"`, a new `_validateFabricXSettings()` path runs instead of the 
classic Fabric checks, enforcing: Docker engine only, TLS required, dev mode 
off, no Explorer/Fablo REST, no chaincodes, exactly one channel.