### PR TITLE
fix(fabric-x): list namespace bugs

### DIFF
--- a/src/setup-docker/templates/fabric-x/config/party1-assembler.yaml
+++ b/src/setup-docker/templates/fabric-x/config/party1-assembler.yaml
@@ -2,7 +2,7 @@ PartyID: 1
 
 General:
   ListenAddress: 0.0.0.0
-  ListenPort: 7050
+  ListenPort: 7053
   TLS:
     Enabled: true
     PrivateKey: /node-tls/server.key

--- a/src/setup-docker/templates/fabric-x/config/party1-batcher.yaml
+++ b/src/setup-docker/templates/fabric-x/config/party1-batcher.yaml
@@ -2,7 +2,7 @@ PartyID: 1
 
 General:
   ListenAddress: 0.0.0.0
-  ListenPort: 7050
+  ListenPort: 7051
   TLS:
     Enabled: true
     PrivateKey: /node-tls/server.key

--- a/src/setup-docker/templates/fabric-x/config/party1-consenter.yaml
+++ b/src/setup-docker/templates/fabric-x/config/party1-consenter.yaml
@@ -2,7 +2,7 @@ PartyID: 1
 
 General:
   ListenAddress: 0.0.0.0
-  ListenPort: 7050
+  ListenPort: 7052
   TLS:
     Enabled: true
     PrivateKey: /node-tls/server.key

--- a/src/setup-docker/templates/fabric-x/config/query-service.yaml
+++ b/src/setup-docker/templates/fabric-x/config/query-service.yaml
@@ -18,6 +18,9 @@ database:
   username: fabricx
   password: fabricx
   database: fabricx
+  max-connections: 1000
+  min-connections: 50
+  load-balance: false
   tls:
     mode: none
 

--- a/src/setup-docker/templates/fabric-x/config/validator.yaml
+++ b/src/setup-docker/templates/fabric-x/config/validator.yaml
@@ -8,26 +8,28 @@ server:
     ca-cert-paths:
       - /org-tls-ca.pem
 monitoring:
-  endpoint: :2115
+  endpoint: :2116
   tls:
     mode: none
 
-state-db:
-  db-type: sql
-  sql:
-    max-open-conns: 1000
-    max-idle-conns: 50
-    conn-max-idle-time: 1m0s
-    postgres:
-      dsn: host=committer-org1-db port=5432 user=fabricx password=fabricx dbname=fabricx sslmode=disable
+database:
+  endpoints:
+    - committer-org1-db:5432
+  username: fabricx
+  password: fabricx
+  database: fabricx
+  max-connections: 1000
+  min-connections: 50
+  load-balance: false
+  tls:
+    mode: none
 
-mvcc-validation:
-  pipeline-size: 10
-  parallel-workers-num: 3
-
-block-committer:
-  pipeline-size: 10
-  parallel-workers-num: 3
+resource-limits:
+  max-workers-for-preparer: 3
+  max-workers-for-validator: 3
+  max-workers-for-committer: 3
+  min-transaction-batch-size: 1
+  timeout-for-min-transaction-batch-size: 5s
 
 identity:
   msp-id: Org1MSP

--- a/src/setup-docker/templates/fabric-x/config/verifier.yaml
+++ b/src/setup-docker/templates/fabric-x/config/verifier.yaml
@@ -8,7 +8,7 @@ server:
     ca-cert-paths:
       - /org-tls-ca.pem
 monitoring:
-  endpoint: :2116
+  endpoint: :2115
   tls:
     mode: none
 

--- a/src/setup-docker/templates/fabric-x/docker-compose.yaml
+++ b/src/setup-docker/templates/fabric-x/docker-compose.yaml
@@ -156,6 +156,12 @@ services:
       - ./config/verifier.yaml:/config/verifier.yaml:ro,Z
       - ./crypto/peerOrganizations/org1.example.com/peers/committer-verifier.org1.example.com/tls:/node-tls:ro,Z
       - ./crypto/peerOrganizations/org1.example.com/msp/tlscacerts/tlsca.org1.example.com-cert.pem:/org-tls-ca.pem:ro,Z
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:2115/metrics"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 10s
     networks:
       - fabric-x
 
@@ -169,12 +175,12 @@ services:
       - ./config/validator.yaml:/config/validator.yaml:ro,Z
       - ./crypto/peerOrganizations/org1.example.com/peers/committer-validator.org1.example.com/tls:/node-tls:ro,Z
       - ./crypto/peerOrganizations/org1.example.com/msp/tlscacerts/tlsca.org1.example.com-cert.pem:/org-tls-ca.pem:ro,Z
-    environment:
-      SC_VC_DATABASE_ENDPOINTS: committer-org1-db:5432
-      SC_VC_DATABASE_DB: postgres
-      SC_VC_DATABASE_USER: fabricx
-      SC_VC_DATABASE_PASSWORD: fabricx
-      SC_VC_DATABASE_NAME: fabricx
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:2116/metrics"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 10s
     depends_on:
       committer-org1-db:
         condition: service_healthy
@@ -191,12 +197,17 @@ services:
       - ./config/committer-coordinator.yaml:/config/coordinator.yaml:ro,Z
       - ./crypto/peerOrganizations/org1.example.com/peers/committer-coordinator.org1.example.com/tls:/node-tls:ro,Z
       - ./crypto/peerOrganizations/org1.example.com/msp/tlscacerts/tlsca.org1.example.com-cert.pem:/org-tls-ca.pem:ro,Z
-    environment:
-      SC_COORDINATOR_VERIFIER_ENDPOINTS: committer-org1-verifier:5001
-      SC_COORDINATOR_VALIDATOR_COMMITTER_ENDPOINTS: committer-org1-validator:6001
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:2119/metrics"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 10s
     depends_on:
-      - committer-org1-verifier
-      - committer-org1-validator
+      committer-org1-verifier:
+        condition: service_healthy
+      committer-org1-validator:
+        condition: service_healthy
     networks:
       - fabric-x
 
@@ -216,9 +227,15 @@ services:
       - ./crypto/ordererOrganizations:/orderer-cas:ro,Z
       - ./crypto/config-block.pb.bin:/bootstrap/genesis.block:ro,Z
       - ./data/committer-org1/sidecar-ledger:/ledger:Z
+    healthcheck:
+      test: ["CMD", "curl", "-sk", "--cert", "/node-tls/server.crt", "--key", "/node-tls/server.key", "https://localhost:2114/metrics"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 10s
     depends_on:
       committer-org1-coordinator:
-        condition: service_started
+        condition: service_healthy
 
       orderer-router:
         condition: service_healthy
@@ -238,12 +255,6 @@ services:
       - ./config/query-service.yaml:/config/query-service.yaml:ro,Z
       - ./crypto/peerOrganizations/org1.example.com/peers/committer-query-service.org1.example.com/tls:/node-tls:ro,Z
       - ./crypto/peerOrganizations/org1.example.com/msp/tlscacerts/tlsca.org1.example.com-cert.pem:/org-tls-ca.pem:ro,Z
-    environment:
-      SC_QUERY_DATABASE_ENDPOINTS: committer-org1-db:5432
-      SC_QUERY_DATABASE_DB: postgres
-      SC_QUERY_DATABASE_USER: fabricx
-      SC_QUERY_DATABASE_PASSWORD: fabricx
-      SC_QUERY_DATABASE_NAME: fabricx
     depends_on:
       committer-org1-db:
         condition: service_healthy
@@ -255,5 +266,3 @@ services:
       start_period: 10s
     networks:
       - fabric-x
-
-

--- a/src/setup-docker/templates/fabric-x/scripts/base-functions.sh
+++ b/src/setup-docker/templates/fabric-x/scripts/base-functions.sh
@@ -9,7 +9,7 @@ printHeadline() {
 }
 
 printStartSuccessInfo() {
-  printHeadline "Done!! Fabric-X network is up" "U1F984"
+  printHeadline "Done! Fabric-X network is up" "U1F984"
   echo "App-level submit/query calls need a namespace."
   echo "Run './fabric-x-docker.sh namespace init' to create the default namespace if needed."
 }

--- a/src/setup-docker/templates/fabric-x/scripts/base-functions.sh
+++ b/src/setup-docker/templates/fabric-x/scripts/base-functions.sh
@@ -9,7 +9,7 @@ printHeadline() {
 }
 
 printStartSuccessInfo() {
-  printHeadline "Done! Fabric-X network is up" "U1F984"
+  printHeadline "Done!! Fabric-X network is up" "U1F984"
   echo "App-level submit/query calls need a namespace."
   echo "Run './fabric-x-docker.sh namespace init' to create the default namespace if needed."
 }

--- a/src/setup-docker/templates/fabric-x/scripts/base-functions.sh
+++ b/src/setup-docker/templates/fabric-x/scripts/base-functions.sh
@@ -10,8 +10,8 @@ printHeadline() {
 
 printStartSuccessInfo() {
   printHeadline "Done! Fabric-X network is up" "U1F984"
-  echo "No namespace has been created yet - app-level submit/query calls need one first."
-  echo "Run './fabric-x-docker.sh namespace init' to create the default namespace."
+  echo "App-level submit/query calls need a namespace."
+  echo "Run './fabric-x-docker.sh namespace init' to create the default namespace if needed."
 }
 
 TOOLS_IMAGE="${TOOLS_IMAGE:-ghcr.io/hyperledger/fabric-x-tools:1.0.0}"
@@ -21,10 +21,19 @@ DEFAULT_POLICY="AND('Org1MSP.member')"
 
 
 generateArtifacts() {
-  if [ -d "$FABRIC_X_ROOT/crypto" ]; then
-    echo "Crypto material already exists, skipping generation."
+  if [ -f "$FABRIC_X_ROOT/crypto/config-block.pb.bin" ] &&
+    [ -f "$FABRIC_X_ROOT/crypto/shared_config.binpb" ] &&
+    [ -f "$FABRIC_X_ROOT/crypto/client-tls-ca.pem" ]; then
+    echo "Fabric-X crypto and config artifacts already exist, skipping generation."
     return
   fi
+
+  if [ -d "$FABRIC_X_ROOT/crypto" ]; then
+    echo "Removing incomplete Fabric-X crypto material..."
+    rm -rf "$FABRIC_X_ROOT/crypto"
+  fi
+
+  mkdir -p "$FABRIC_X_ROOT/crypto"
 
   echo "Generating Fabric-X crypto material..."
   docker run --rm --user "$(id -u):$(id -g)" \


### PR DESCRIPTION

Fixes for config issues

1. Fixed party1-batcher.yaml, party1-consenter.yaml, party1-assembler.yaml (had 7050  changed to 7051/7052/7053).
2. Fixed validator.yaml, replaced state-db section with the database section, same as query-service.yaml.
3. Fixed verifier.yaml/validator.yaml
4. Added healthchecks for verifier, validator, coordinator, sidecar in docker-compose.yaml
5. generateArtifacts() now checks for the actual output files (not just the crypto folder existing) before skipping regeneration, and cleans up incomplete state automatically.

Applied and retested locally