### PR TITLE
feat(fabric-x): Add fablo init fabric-x

### DIFF
--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -95,7 +95,6 @@ function getDefaultFabricXConfig(): FabloConfigJson {
         orderers: [
           {
             groupName: "group1",
-
             type: "BFT",
             instances: 1,
             prefix: "orderer",

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -8,7 +8,7 @@ import * as fs from "fs-extra";
 import { version } from "../../../package.json";
 import { schema } from "../../config";
 
-function getDefaultFabloConfig(): FabloConfigJson {
+function getFabricConfig(): FabloConfigJson {
   return {
     $schema: `https://github.com/hyperledger-labs/fablo/releases/download/${version}/schema.json`,
     global: {
@@ -70,6 +70,51 @@ function getDefaultFabloConfig(): FabloConfigJson {
   };
 }
 
+
+function getFabricXConfig(): FabloConfigJson {
+  return {
+    $schema: `https://github.com/hyperledger-labs/fablo/releases/download/${version}/schema.json`,
+    global: {
+      fabricVersion: "3.1.0",
+      tls: true,
+      engine: "docker",
+      peerDevMode: false,
+      provider: "fabric-x",
+    },
+    orgs: [
+      {
+        organization: {
+          name: "Org1",
+          domain: "org1.example.com",
+          mspName: "Org1MSP",
+        },
+        ca: {
+          prefix: "ca",
+          db: "sqlite",
+        },
+        orderers: [],
+      },
+    ],
+    channels: [
+      {
+        name: "mychannel",
+        orgs: [
+          {
+            name: "Org1",
+            peers: [],
+          },
+        ],
+      },
+    ],
+    chaincodes: [],
+    hooks: {},
+  };
+}
+
+function getDefaultFabloConfig(fabricX = false): FabloConfigJson {
+  return fabricX ? getFabricXConfig() : getFabricConfig();
+}
+
 export function parseOverrideValue(raw: string): unknown {
   const trimmed = raw.trim();
   if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
@@ -117,7 +162,7 @@ export default class Init extends Command {
     options: Args.string({
       multiple: true,
       required: false,
-      description: "Options: node, dev, ccaas, gateway, rest (order does not matter)",
+      description: "Options: node, dev, ccaas, gateway, rest, fabric-x (order does not matter)",
     }),
   };
 
@@ -136,8 +181,9 @@ export default class Init extends Command {
     ccaas: boolean;
     gateway: boolean;
     rest: boolean;
+    fabricX: boolean;
   } {
-    const validOptions = ["node", "dev", "ccaas", "gateway", "rest"] as const;
+    const validOptions = ["node", "dev", "ccaas", "gateway", "rest", "fabric-x"] as const;
     const optionsArr = Array.isArray(args?.options) ? args.options : args?.options ? [args.options] : [];
     const raw = optionsArr.filter((s) => !s.startsWith("-")).map((s) => s.toLowerCase());
     const invalid = raw.filter((o) => !validOptions.includes(o as (typeof validOptions)[number]));
@@ -150,11 +196,11 @@ export default class Init extends Command {
       ccaas: raw.includes("ccaas"),
       gateway: raw.includes("gateway"),
       rest: raw.includes("rest"),
+      fabricX: raw.includes("fabric-x"),
     };
   }
 
   async copySampleConfig(): Promise<void> {
-    let fabloConfigJson = getDefaultFabloConfig();
     const parsed = await this.parse(Init);
     const argv = (parsed.argv ?? []) as string[];
 
@@ -163,6 +209,20 @@ export default class Init extends Command {
       this.error(`Unknown option(s): ${unsupportedArgs.join(", ")}. ` + `Did you mean --set <path>=<value>?`);
     }
     const flags = this.getEffectiveFlags({ options: argv });
+
+    if (flags.fabricX) {
+      const incompatible = (["node", "dev", "ccaas", "gateway", "rest"] as const).filter((opt) => flags[opt]);
+      if (incompatible.length > 0) {
+        this.error(`Error: fabric-x cannot be used together with ${incompatible.join(", ")}`);
+      }
+    }
+
+    let fabloConfigJson = getDefaultFabloConfig(flags.fabricX);
+
+    if (flags.fabricX) {
+      console.log("Creating minimal Fabric-X starter config");
+    }
+
     if (flags.ccaas) {
       if (flags.dev || flags.node) {
         this.log(chalk.red("Error: ccaas cannot be used together with dev or node"));

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -220,7 +220,7 @@ export default class Init extends Command {
     let fabloConfigJson = getDefaultFabloConfig(flags.fabricX);
 
     if (flags.fabricX) {
-      console.log("Creating minimal Fabric-X starter config");
+      this.log("Creating minimal Fabric-X starter config");
     }
 
     if (flags.ccaas) {

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -71,7 +71,7 @@ function getFabricConfig(): FabloConfigJson {
 }
 
 
-function getFabricXConfig(): FabloConfigJson {
+function getDefaultFabricXConfig(): FabloConfigJson {
   return {
     $schema: `https://github.com/hyperledger-labs/fablo/releases/download/${version}/schema.json`,
     global: {
@@ -92,7 +92,15 @@ function getFabricXConfig(): FabloConfigJson {
           prefix: "ca",
           db: "sqlite",
         },
-        orderers: [],
+        orderers: [
+          {
+            groupName: "group1",
+
+            type: "BFT",
+            instances: 1,
+            prefix: "orderer",
+          },
+        ],
       },
     ],
     channels: [
@@ -111,8 +119,8 @@ function getFabricXConfig(): FabloConfigJson {
   };
 }
 
-function getDefaultFabloConfig(fabricX = false): FabloConfigJson {
-  return fabricX ? getFabricXConfig() : getFabricConfig();
+function getDefaultFabloConfig(): FabloConfigJson {
+  return getFabricConfig();
 }
 
 export function parseOverrideValue(raw: string): unknown {
@@ -217,7 +225,7 @@ export default class Init extends Command {
       }
     }
 
-    let fabloConfigJson = getDefaultFabloConfig(flags.fabricX);
+   let fabloConfigJson = flags.fabricX ? getDefaultFabricXConfig() : getDefaultFabloConfig();
 
     if (flags.fabricX) {
       this.log("Creating minimal Fabric-X starter config");


### PR DESCRIPTION
fixes  #809

This adds a new init option that generates a minimal starter config for Fabric X, following the same pattern as the existing init node option.

Changes:

1)Added fabric-x as a valid option in the init command argument parser, alongside the existing ones

2)Added a fabricX boolean to the parsed flags result.

3)Split the config generation into two functions, one for the regular Fabric starter config and one for the new Fabric X starter config, and getDefaultFabloConfig now picks between them based on the fabricX flag.

4)fixed values for the proof of concept: fabricVersion 3.1.0, tls true, engine docker, peerDevMode false. It includes one application org called Org1 with Org1MSP and org1.example.com, one channel called mychannel, and empty chaincodes and hooks. The output is still a normal fablo-config.json file pointing at the same schema, so it validates the same way as any other config.
