### PR TITLE
feat: Making the Fabric-X channel configurable

### DIFF
--- a/src/setup-docker/templates/fabric-x/configtx.yaml
+++ b/src/setup-docker/templates/fabric-x/configtx.yaml
@@ -149,7 +149,7 @@ Channel: &ChannelDefaults
     <<: *ChannelCapabilities
 
 Profiles:
-  OrgsChannel:
+  <%= channels[0].profileName %>:
     <<: *ChannelDefaults
     Orderer:
       <<: *OrdererDefaults

--- a/src/setup-docker/templates/fabric-x/fxconfig.yaml
+++ b/src/setup-docker/templates/fabric-x/fxconfig.yaml
@@ -7,7 +7,7 @@ msp:
 
 orderer:
   address: orderer-router:7050
-  channel: mychannel
+  channel: <%= channels[0].name %>
   tls:
     enabled: true
     clientCert: /tls/server.crt

--- a/src/setup-docker/templates/fabric-x/scripts/base-functions.sh
+++ b/src/setup-docker/templates/fabric-x/scripts/base-functions.sh
@@ -58,7 +58,7 @@ generateArtifacts() {
   docker run --rm --user "$(id -u):$(id -g)" \
     -v "$FABRIC_X_ROOT:/config" \
     "$TOOLS_IMAGE" \
-    configtxgen --channelID <%= channels[0].name %> --profile <%= channels[0].profileName %> \\
+    configtxgen --channelID <%= channels[0].name %> --profile <%= channels[0].profileName %> \
     --outputBlock /config/crypto/config-block.pb.bin \
     --configPath /config
 }

--- a/src/setup-docker/templates/fabric-x/scripts/base-functions.sh
+++ b/src/setup-docker/templates/fabric-x/scripts/base-functions.sh
@@ -58,7 +58,7 @@ generateArtifacts() {
   docker run --rm --user "$(id -u):$(id -g)" \
     -v "$FABRIC_X_ROOT:/config" \
     "$TOOLS_IMAGE" \
-    configtxgen --channelID mychannel --profile OrgsChannel \
+    configtxgen --channelID <%= channels[0].name %> --profile <%= channels[0].profileName %> \\
     --outputBlock /config/crypto/config-block.pb.bin \
     --configPath /config
 }


### PR DESCRIPTION
fixes #817

**What it does**

Fabric-X generation was hardcoding the channel name (`mychannel`) instead of reading it from `fablo-config.json`. This makes the channel name configurable.

 **Changes**

1. `src/setup-docker/templates/fabric-x/scripts/base-functions.sh` — `configtxgen --channelID` now uses `<%= channels[0].name %>` instead of the hardcoded `mychannel`.
2. `src/setup-docker/templates/fabric-x/fxconfig.yaml` — `channel:` field now uses `<%= channels[0].name %>` instead of the hardcoded `mychannel`.


